### PR TITLE
SAP-1596: Changes dockerfile to use our fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM hapiproject/hapi:base as build-hapi
 
-ARG HAPI_FHIR_URL=https://github.com/jamesagnew/hapi-fhir/
+ARG HAPI_FHIR_URL=https://github.com/elimuinformatics/hapi-fhir.git
 ARG HAPI_FHIR_BRANCH=master
-ARG HAPI_FHIR_STARTER_URL=https://github.com/hapifhir/hapi-fhir-jpaserver-starter/
+ARG HAPI_FHIR_STARTER_URL=https://github.com/elimuinformatics/hapi-fhir-jpaserver-starter.git
 ARG HAPI_FHIR_STARTER_BRANCH=master
 
 RUN git clone --branch ${HAPI_FHIR_BRANCH} ${HAPI_FHIR_URL}


### PR DESCRIPTION
Changes the `Dockerfile` to use our fork of the open-source project.

The goal is to make the fewest changes possible to this, and the `hapi-fhir`, forked repos so that it will be easier to merge upstream changes from the open-source project.

The only reason to use our fork of the `hapi-fhir` repo instead of the open-source repo is to give us the option to patch it if needed and submit pull requests to the open-source project.