### PR TITLE
SAP-1687 Updated code to allow metadata request for server healthcheck

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomAuthorizationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomAuthorizationInterceptor.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.util.StringUtils;
 
 import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizationInterceptor;
 import ca.uhn.fhir.rest.server.interceptor.auth.IAuthRule;
@@ -28,10 +29,9 @@ public class CustomAuthorizationInterceptor extends AuthorizationInterceptor {
 				return authorizeRequest();
 			} else if (!StringUtils.isEmpty(token) && token.equals(System.getenv(API_KEY))) {
 				return authorizeRequest();
-			} else {
-				return denyRequest();
+			} else {				
+				return (theRequestDetails.getOperation().equals(RestOperationTypeEnum.METADATA.getCode()))  ? authorizeRequest() : denyRequest();
 			}
-
 		} catch (Exception e) {
 			return denyRequest();
 		}


### PR DESCRIPTION
Updated code to bypass metadata request in order to add healthchecks for target groups.
metadata request is nothing but conformance statement request.