### PR TITLE
Allow legacy queries to support SOF launcher

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/BaseJpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/BaseJpaRestfulServer.java
@@ -106,7 +106,7 @@ public class BaseJpaRestfulServer extends RestfulServer {
   @Override
   protected void initialize() throws ServletException {
     super.initialize();
-
+    daoConfig.setUseLegacySearchBuilder(true);
     /*
      * Create a FhirContext object that uses the version of FHIR
      * specified in the properties file.


### PR DESCRIPTION
This change is done to support launching the app from the SMART on FHIR launcher. When app is launched SOF queries with some parameters which are supported in hibernate legacy sql builder.
e.g. _sort:desc=date this parameter is passed to get the encounter of patient.