### PR TITLE
As a user i can get oauth urls from a hapi fhir server

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomServerCapabilityStatementProviderR4.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomServerCapabilityStatementProviderR4.java
@@ -1,9 +1,7 @@
 package ca.uhn.fhir.jpa.starter;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletRequest;
@@ -16,8 +14,6 @@ import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.UriType;
 import org.springframework.context.annotation.Configuration;
 
-import com.google.gson.Gson;
-
 import ca.uhn.fhir.jpa.api.config.DaoConfig;
 import ca.uhn.fhir.jpa.api.dao.IFhirSystemDao;
 import ca.uhn.fhir.jpa.provider.r4.JpaConformanceProviderR4;
@@ -28,7 +24,8 @@ import ca.uhn.fhir.rest.server.RestfulServer;
 @Configuration
 public class CustomServerCapabilityStatementProviderR4 extends JpaConformanceProviderR4 {
 
-	private static final String EXTENSION_MAP = System.getenv("OAUTH_CAPABILITY_EXTENSION");
+	private static final String OAUTH_TOKEN_URL = System.getenv("OAUTH_TOKEN_URL");
+	private static final String OAUTH_MANAGE_URL = System.getenv("OAUTH_MANAGE_URL");
 	
 	private CapabilityStatement capabilityStatement;
 
@@ -49,13 +46,10 @@ public class CustomServerCapabilityStatementProviderR4 extends JpaConformancePro
 	}
 	
 	private static CapabilityStatementRestSecurityComponent getSecurityComponent() {
-		Gson json = new Gson();
-		Map<String, String> oauthUrl = json.fromJson(EXTENSION_MAP, HashMap.class);
 		CapabilityStatementRestSecurityComponent security = new CapabilityStatementRestSecurityComponent();
 		List<Extension> extensions = new ArrayList<Extension>();
-		oauthUrl.entrySet().forEach(entry -> {
-			extensions.add(new Extension(entry.getValue(), new UriType(entry.getKey())));
-		});
+		extensions.add(new Extension("token", new UriType(OAUTH_TOKEN_URL)));
+		extensions.add(new Extension("manage", new UriType(OAUTH_MANAGE_URL)));
 		List<Extension> extensionsList = new ArrayList<Extension>();
 		extensionsList.add((Extension) new Extension(
 				new UriType("http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris"))

--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomServerCapabilityStatementProviderR4.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomServerCapabilityStatementProviderR4.java
@@ -1,0 +1,66 @@
+package ca.uhn.fhir.jpa.starter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+import javax.servlet.http.HttpServletRequest;
+
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementRestSecurityComponent;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Meta;
+import org.hl7.fhir.r4.model.UriType;
+import org.springframework.context.annotation.Configuration;
+
+import com.google.gson.Gson;
+
+import ca.uhn.fhir.jpa.api.config.DaoConfig;
+import ca.uhn.fhir.jpa.api.dao.IFhirSystemDao;
+import ca.uhn.fhir.jpa.provider.r4.JpaConformanceProviderR4;
+import ca.uhn.fhir.jpa.searchparam.registry.ISearchParamRegistry;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.RestfulServer;
+
+@Configuration
+public class CustomServerCapabilityStatementProviderR4 extends JpaConformanceProviderR4 {
+
+	private static final String EXTENSION_MAP = System.getenv("OAUTH_CAPABILITY_EXTENSION");
+	
+	private CapabilityStatement capabilityStatement;
+
+	public CustomServerCapabilityStatementProviderR4 () {
+		super();
+	}
+	
+	public CustomServerCapabilityStatementProviderR4(@Nonnull RestfulServer theRestfulServer, @Nonnull IFhirSystemDao<Bundle, Meta> theSystemDao, @Nonnull DaoConfig theDaoConfig, @Nonnull ISearchParamRegistry theSearchParamRegistry) {
+		super(theRestfulServer, theSystemDao, theDaoConfig, theSearchParamRegistry);
+	}
+	
+	
+	@Override
+	public CapabilityStatement getServerConformance(HttpServletRequest theRequest, RequestDetails theRequestDetails) {
+		capabilityStatement = super.getServerConformance(theRequest, theRequestDetails);
+		capabilityStatement.getRest().get(0).setSecurity(getSecurityComponent());
+		return capabilityStatement;
+	}
+	
+	private static CapabilityStatementRestSecurityComponent getSecurityComponent() {
+		Gson json = new Gson();
+		Map<String, String> oauthUrl = json.fromJson(EXTENSION_MAP, HashMap.class);
+		CapabilityStatementRestSecurityComponent security = new CapabilityStatementRestSecurityComponent();
+		List<Extension> extensions = new ArrayList<Extension>();
+		oauthUrl.entrySet().forEach(entry -> {
+			extensions.add(new Extension(entry.getValue(), new UriType(entry.getKey())));
+		});
+		List<Extension> extensionsList = new ArrayList<Extension>();
+		extensionsList.add((Extension) new Extension(
+				new UriType("http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris"))
+						.setExtension(extensions));
+		security.setExtension(extensionsList);
+		return security;
+	}
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
@@ -30,7 +30,7 @@ public class JpaRestfulServer extends BaseJpaRestfulServer {
     // Add your own customization here
     
     /* Custom ServerConformanceProvider will be triggered when fhir version is R4 and Oauth is enabled. */
-    if(FHIR_VERSION.equals(FhirVersionEnum.R4.name()) && Boolean.parseBoolean(OAUTH_ENABLED)) {
+    if (FHIR_VERSION.equals(FhirVersionEnum.R4.name()) && Boolean.parseBoolean(OAUTH_ENABLED)) {
     	CustomServerCapabilityStatementProviderR4 customCapabilityStatementProviderR4 = new CustomServerCapabilityStatementProviderR4(this, fhirSystemDao,
     	          daoConfig, searchParamRegistry);
     	setServerConformanceProvider(customCapabilityStatementProviderR4);

--- a/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
@@ -5,13 +5,20 @@ import javax.servlet.ServletException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 
+import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizationInterceptor;
 
 @Import(AppProperties.class)
 public class JpaRestfulServer extends BaseJpaRestfulServer {
+	
+	private static final String FHIR_VERSION = System.getenv("fhir_version");
+	private static final String OAUTH_ENABLED = System.getenv("OAUTH_ENABLED");
 
   @Autowired
   AppProperties appProperties;
+  
+  @Autowired
+  CustomServerCapabilityStatementProviderR4 customCapabilityStatementProviderR4;
 
   private static final long serialVersionUID = 1L;
 
@@ -24,8 +31,15 @@ public class JpaRestfulServer extends BaseJpaRestfulServer {
     super.initialize();
 
     // Add your own customization here
+    
+    /* Custom ServerConformanceProvider will be triggered when fhir version is R4 and Oath is enabled. */
+    if(FHIR_VERSION.equals(FhirVersionEnum.R4.name()) && Boolean.parseBoolean(OAUTH_ENABLED) ) {
+    	CustomServerCapabilityStatementProviderR4 customCapabilityStatementProviderR4 = new CustomServerCapabilityStatementProviderR4(this, fhirSystemDao,
+    	          daoConfig, searchParamRegistry);
+    	setServerConformanceProvider(customCapabilityStatementProviderR4);
+    }
     AuthorizationInterceptor authorizationInterceptor = new CustomAuthorizationInterceptor();
     this.registerInterceptor(authorizationInterceptor);
   }
-
+  
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
@@ -16,9 +16,6 @@ public class JpaRestfulServer extends BaseJpaRestfulServer {
 
   @Autowired
   AppProperties appProperties;
-  
-  @Autowired
-  CustomServerCapabilityStatementProviderR4 customCapabilityStatementProviderR4;
 
   private static final long serialVersionUID = 1L;
 
@@ -33,7 +30,7 @@ public class JpaRestfulServer extends BaseJpaRestfulServer {
     // Add your own customization here
     
     /* Custom ServerConformanceProvider will be triggered when fhir version is R4 and Oath is enabled. */
-    if(FHIR_VERSION.equals(FhirVersionEnum.R4.name()) && Boolean.parseBoolean(OAUTH_ENABLED) ) {
+    if(FHIR_VERSION.equals(FhirVersionEnum.R4.name()) && Boolean.parseBoolean(OAUTH_ENABLED)) {
     	CustomServerCapabilityStatementProviderR4 customCapabilityStatementProviderR4 = new CustomServerCapabilityStatementProviderR4(this, fhirSystemDao,
     	          daoConfig, searchParamRegistry);
     	setServerConformanceProvider(customCapabilityStatementProviderR4);
@@ -41,5 +38,5 @@ public class JpaRestfulServer extends BaseJpaRestfulServer {
     AuthorizationInterceptor authorizationInterceptor = new CustomAuthorizationInterceptor();
     this.registerInterceptor(authorizationInterceptor);
   }
-  
+
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
@@ -29,7 +29,7 @@ public class JpaRestfulServer extends BaseJpaRestfulServer {
 
     // Add your own customization here
     
-    /* Custom ServerConformanceProvider will be triggered when fhir version is R4 and Oath is enabled. */
+    /* Custom ServerConformanceProvider will be triggered when fhir version is R4 and Oauth is enabled. */
     if(FHIR_VERSION.equals(FhirVersionEnum.R4.name()) && Boolean.parseBoolean(OAUTH_ENABLED)) {
     	CustomServerCapabilityStatementProviderR4 customCapabilityStatementProviderR4 = new CustomServerCapabilityStatementProviderR4(this, fhirSystemDao,
     	          daoConfig, searchParamRegistry);


### PR DESCRIPTION
This will allow to expose authorization url's in metadata request.
It will work only when Oauth is enabled and fhir version is R4.
For that we need to set environment variables "OAUTH_TOKEN_URL" and "OAUTH_MANAGE_URL"
Attaching metadata response
```
{
  "rest": [
    {
      "extension": [
        {
          "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-websocket",
          "valueUri": "/websocket"
        }
      ],
      "mode": "server",
      "security": {
        "extension": [
          {
            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris",
            "extension": [
              {
                "url": "token",
                "valueUri": "https://auth-internal.elimuinformatics.com/auth/realms/product/protocol/openid-connect/token"
              },
              {
                "url": "manage",
                "valueUri": "https://auth-internal.elimuinformatics.com/auth/realms/product/account/"
              }
            ]
          }
        ]
      }
    }
  ]
}
```