### PR TITLE
Implement custom search narrowing interceptor

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomAuthorizationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomAuthorizationInterceptor.java
@@ -139,4 +139,8 @@ public class CustomAuthorizationInterceptor extends AuthorizationInterceptor {
 		logger.info("Authorization failure - invalid X-API-KEY header");
 		return denyAll();
 	}
+
+	public static String getTokenPrefix() {
+		return TOKEN_PREFIX;
+	}
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomSearchNarrowingInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomSearchNarrowingInterceptor.java
@@ -10,7 +10,7 @@ import ca.uhn.fhir.rest.server.interceptor.auth.SearchNarrowingInterceptor;
 @Interceptor
 public class CustomSearchNarrowingInterceptor extends SearchNarrowingInterceptor {
 
-  private static final String CLAIM_NAME = System.getenv("claim_name");
+  private static final String OAUTH_CLAIM_NAME = System.getenv("OAUTH_CLAIM_NAME");
   
   private OAuth2Helper oAuth2Helper = new OAuth2Helper();
 
@@ -29,7 +29,7 @@ public class CustomSearchNarrowingInterceptor extends SearchNarrowingInterceptor
     if (token != null) {
       token = token.substring(CustomAuthorizationInterceptor.getTokenPrefix().length());
       DecodedJWT jwt = JWT.decode(token);
-      String patRefId = oAuth2Helper.getPatientReferenceFromToken(jwt, CLAIM_NAME);
+      String patRefId = oAuth2Helper.getPatientReferenceFromToken(jwt, OAUTH_CLAIM_NAME);
       return patRefId;
     }
     return null;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomSearchNarrowingInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomSearchNarrowingInterceptor.java
@@ -10,7 +10,7 @@ import ca.uhn.fhir.rest.server.interceptor.auth.SearchNarrowingInterceptor;
 @Interceptor
 public class CustomSearchNarrowingInterceptor extends SearchNarrowingInterceptor {
 
-  private static final String OAUTH_CLAIM_NAME = "subject";
+  private static final String OAUTH_CLAIM_NAME = "patient";
   
   private OAuth2Helper oAuth2Helper = new OAuth2Helper();
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomSearchNarrowingInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomSearchNarrowingInterceptor.java
@@ -10,7 +10,7 @@ import ca.uhn.fhir.rest.server.interceptor.auth.SearchNarrowingInterceptor;
 @Interceptor
 public class CustomSearchNarrowingInterceptor extends SearchNarrowingInterceptor {
 
-  private static final String OAUTH_CLAIM_NAME = System.getenv("OAUTH_CLAIM_NAME");
+  private static final String OAUTH_CLAIM_NAME = "subject";
   
   private OAuth2Helper oAuth2Helper = new OAuth2Helper();
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomSearchNarrowingInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomSearchNarrowingInterceptor.java
@@ -1,0 +1,29 @@
+package ca.uhn.fhir.jpa.starter;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizedList;
+import ca.uhn.fhir.rest.server.interceptor.auth.SearchNarrowingInterceptor;
+
+@Interceptor
+public class CustomSearchNarrowingInterceptor extends SearchNarrowingInterceptor {
+  private OAuth2Helper oAuth2Helper = new OAuth2Helper();
+
+  @Override
+  protected AuthorizedList buildAuthorizedList(RequestDetails theRequestDetails) {
+    String patientId = getPatientFromToken(theRequestDetails);
+    String patientRef = "Patient/" + patientId;
+    return new AuthorizedList().addCompartment(patientRef);
+  }
+
+  private String getPatientFromToken(RequestDetails theRequestDetails) {
+    String token = theRequestDetails.getHeader("Authorization");
+    token = token.substring(CustomAuthorizationInterceptor.getTokenPrefix().length());
+    DecodedJWT jwt = JWT.decode(token);
+    String patRefId = oAuth2Helper.getPatientReferenceFromToken(jwt);
+    return patRefId;
+  }
+
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomSearchNarrowingInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomSearchNarrowingInterceptor.java
@@ -14,16 +14,22 @@ public class CustomSearchNarrowingInterceptor extends SearchNarrowingInterceptor
   @Override
   protected AuthorizedList buildAuthorizedList(RequestDetails theRequestDetails) {
     String patientId = getPatientFromToken(theRequestDetails);
-    String patientRef = "Patient/" + patientId;
-    return new AuthorizedList().addCompartment(patientRef);
+    if (patientId != null) {
+      String patientRef = "Patient/" + patientId;
+      return new AuthorizedList().addCompartment(patientRef);
+    }
+    return new AuthorizedList();
   }
 
   private String getPatientFromToken(RequestDetails theRequestDetails) {
     String token = theRequestDetails.getHeader("Authorization");
-    token = token.substring(CustomAuthorizationInterceptor.getTokenPrefix().length());
-    DecodedJWT jwt = JWT.decode(token);
-    String patRefId = oAuth2Helper.getPatientReferenceFromToken(jwt);
-    return patRefId;
+    if (token != null) {
+      token = token.substring(CustomAuthorizationInterceptor.getTokenPrefix().length());
+      DecodedJWT jwt = JWT.decode(token);
+      String patRefId = oAuth2Helper.getPatientReferenceFromToken(jwt);
+      return patRefId;
+    }
+    return null;
   }
 
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomSearchNarrowingInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomSearchNarrowingInterceptor.java
@@ -9,6 +9,9 @@ import ca.uhn.fhir.rest.server.interceptor.auth.SearchNarrowingInterceptor;
 
 @Interceptor
 public class CustomSearchNarrowingInterceptor extends SearchNarrowingInterceptor {
+
+  private static final String CLAIM_NAME = System.getenv("claim_name");
+  
   private OAuth2Helper oAuth2Helper = new OAuth2Helper();
 
   @Override
@@ -26,7 +29,7 @@ public class CustomSearchNarrowingInterceptor extends SearchNarrowingInterceptor
     if (token != null) {
       token = token.substring(CustomAuthorizationInterceptor.getTokenPrefix().length());
       DecodedJWT jwt = JWT.decode(token);
-      String patRefId = oAuth2Helper.getPatientReferenceFromToken(jwt);
+      String patRefId = oAuth2Helper.getPatientReferenceFromToken(jwt, CLAIM_NAME);
       return patRefId;
     }
     return null;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Import;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizationInterceptor;
+import ca.uhn.fhir.rest.server.interceptor.auth.SearchNarrowingInterceptor;
 
 @Import(AppProperties.class)
 public class JpaRestfulServer extends BaseJpaRestfulServer {
@@ -35,6 +36,8 @@ public class JpaRestfulServer extends BaseJpaRestfulServer {
     	          daoConfig, searchParamRegistry);
     	setServerConformanceProvider(customCapabilityStatementProviderR4);
     }
+    SearchNarrowingInterceptor customSearchNarrowingInterceptor = new CustomSearchNarrowingInterceptor();
+    this.registerInterceptor(customSearchNarrowingInterceptor);
     AuthorizationInterceptor authorizationInterceptor = new CustomAuthorizationInterceptor();
     this.registerInterceptor(authorizationInterceptor);
   }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/OAuth2Helper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/OAuth2Helper.java
@@ -115,5 +115,11 @@ public class OAuth2Helper {
 		ArrayList<String> roles = clientMap.getOrDefault("roles", new ArrayList<String>());
 		return roles.contains(userRole);
 	}
+	
+	protected String getPatientReferenceFromToken(DecodedJWT jwt) {
+		Claim claim = jwt.getClaim("Patient");
+		String patientRef = claim.as(String.class);
+		return patientRef;
+		}
 
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/OAuth2Helper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/OAuth2Helper.java
@@ -115,11 +115,14 @@ public class OAuth2Helper {
 		ArrayList<String> roles = clientMap.getOrDefault("roles", new ArrayList<String>());
 		return roles.contains(userRole);
 	}
-	
-	protected String getPatientReferenceFromToken(DecodedJWT jwt) {
-		Claim claim = jwt.getClaim("Patient");
-		String patientRef = claim.as(String.class);
-		return patientRef;
+
+	protected String getPatientReferenceFromToken(DecodedJWT jwt, String claimName) {
+		if (claimName != null) {
+			Claim claim = jwt.getClaim(claimName);
+			String patientRef = claim.as(String.class);
+			return patientRef;
 		}
+		return null;
+	}
 
 }


### PR DESCRIPTION
Added custom search narrow interceptor.
This enable us to filter resource and show resource for particular patient only who's Id is provided in token.
This filter will only work when oauth is enables and a claim is passed through token.
Claim passed through token is custom claim  and its value is set "patient".