### PR TITLE
Added consent rule for bundle type resource  

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomAuthorizationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomAuthorizationInterceptor.java
@@ -119,6 +119,7 @@ public class CustomAuthorizationInterceptor extends AuthorizationInterceptor {
     return new RuleBuilder()
         .allow().read().allResources().inCompartment("Patient", new IdType("Patient", patientId)).andThen()
         .allow().write().allResources().inCompartment("Patient", new IdType("Patient", patientId)).andThen()
+        .allow().transaction().withAnyOperation().andApplyNormalRules().andThen()
         .denyAll()
         .build();
 	}


### PR DESCRIPTION
Before this operations on bundle resources where getting rejected due to new rule builder.
Added rule to check for proper patient reference for bundle resource and then allow operations.
This will reject all operations in a bundle if any of the request does not have proper reference. 