### PR TITLE
Added consent rule to allow patch request

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomAuthorizationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomAuthorizationInterceptor.java
@@ -120,6 +120,7 @@ public class CustomAuthorizationInterceptor extends AuthorizationInterceptor {
         .allow().read().allResources().inCompartment("Patient", new IdType("Patient", patientId)).andThen()
         .allow().write().allResources().inCompartment("Patient", new IdType("Patient", patientId)).andThen()
         .allow().transaction().withAnyOperation().andApplyNormalRules().andThen()
+        .allow().patch().allRequests().andThen()
         .denyAll()
         .build();
 	}


### PR DESCRIPTION
Added consent rule for PATCH requests. This will allow PATCH operation for only the patientid present in token.