### PR TITLE
Add basic auth

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/BasicAuthHelper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/BasicAuthHelper.java
@@ -1,0 +1,12 @@
+package ca.uhn.fhir.jpa.starter;
+
+import java.util.Base64;
+
+public class BasicAuthHelper {
+
+  public boolean isValid(String basicAuthUsername, String basicAuthPass, String basicAuthToken) {
+    String unEncodedUsernamePass = basicAuthUsername + ":" + basicAuthPass;
+    String encodedUsernamePass = Base64.getEncoder().encodeToString(unEncodedUsernamePass.getBytes());
+    return encodedUsernamePass.equals(basicAuthToken);
+  }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomAuthorizationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomAuthorizationInterceptor.java
@@ -30,12 +30,17 @@ public class CustomAuthorizationInterceptor extends AuthorizationInterceptor {
 	private static final String APIKEY_ENABLED = System.getenv("APIKEY_ENABLED");
 	private static final String APIKEY_HEADER = "x-api-key";
 	private static final String APIKEY = System.getenv("APIKEY");
-	private static final String TOKEN_PREFIX = "BEARER ";
+	private static final String OAUTH_TOKEN_PREFIX = "BEARER ";
 	private static final String OAUTH_USER_ROLE = System.getenv("OAUTH_USER_ROLE");
 	private static final String OAUTH_CLIENT_ID = System.getenv("OAUTH_CLIENT_ID");
 	private static final String OAUTH_ADMIN_ROLE = System.getenv("OAUTH_ADMIN_ROLE");
+	private static final String BASIC_AUTH_ENABLED = System.getenv("BASIC_AUTH_ENABLED");
+	private static final String BASIC_AUTH_USERNAME = System.getenv("BASIC_AUTH_USERNAME");
+	private static final String BASIC_AUTH_PASS = System.getenv("BASIC_AUTH_PASS");
+	private static final String BASIC_AUTH_TOKEN_PREFIX = "BASIC ";
 	private static PublicKey publicKey = null;
 	private static OAuth2Helper oAuth2Helper = new OAuth2Helper();
+	private static BasicAuthHelper basicAuthHelper = new BasicAuthHelper();
 
 	@Override
 	public List<IAuthRule> buildRuleList(RequestDetails theRequest) {
@@ -45,12 +50,12 @@ public class CustomAuthorizationInterceptor extends AuthorizationInterceptor {
 				return allowAll();
 			}
 
-			if (!isOAuthEnabled() && !isApiKeyEnabled()) {
-				logger.warn("APIKEY and OAuth2 authentication are disabled");
+			if (!isOAuthEnabled() && !isApiKeyEnabled() && !isBasicAuthEnabled()) {
+				logger.warn("APIKEY, BasicAuth and OAuth2 authentication are disabled");
 				return allowAll();
 			}
 
-			if (isOAuthEnabled() && isOAuthHeaderPresent(theRequest)) {
+			if (isOAuthEnabled() && oAuth2Helper.isOAuthHeaderPresent(theRequest)) {
 				logger.info("Auhorizing via OAuth");
 				return authorizeOAuth(theRequest);
 			}
@@ -58,6 +63,10 @@ public class CustomAuthorizationInterceptor extends AuthorizationInterceptor {
 			if (isApiKeyEnabled() && isApiKeyHeaderPresent(theRequest)) {
 				logger.info("Auhorizing via X-API-KEY");
 				return authorizeApiKey(theRequest);
+			}
+			if (isBasicAuthEnabled() && isBasicAuthHeaderPresent(theRequest)) {
+				logger.info("Auhorizing via BasicAuth");
+				return authorizeBasicAuth(theRequest);
 			}
 		} catch (Exception e) {
 			logger.info("Unexpected authorization error", e);
@@ -83,12 +92,12 @@ public class CustomAuthorizationInterceptor extends AuthorizationInterceptor {
 			return denyAll();
 		}
 
-		if (!token.toUpperCase().startsWith(TOKEN_PREFIX)) {
+		if (!token.toUpperCase().startsWith(OAUTH_TOKEN_PREFIX)) {
 			logger.info("Authorization failure - invalid authorization header");
 			return denyAll();
 		}
 
-		token = token.substring(TOKEN_PREFIX.length());
+		token = token.substring(OAUTH_TOKEN_PREFIX.length());
 
 		try {
 			DecodedJWT jwt = JWT.decode(token);
@@ -143,10 +152,14 @@ public class CustomAuthorizationInterceptor extends AuthorizationInterceptor {
 	private Boolean isOAuthEnabled() {
 		return ((OAUTH_ENABLED != null) && Boolean.parseBoolean(OAUTH_ENABLED));
 	}
-
-	private Boolean isOAuthHeaderPresent(RequestDetails theRequest) {
+	
+	private Boolean isBasicAuthEnabled() {
+		return ((BASIC_AUTH_ENABLED != null) && Boolean.parseBoolean(BASIC_AUTH_ENABLED));
+	}
+	
+	private Boolean isBasicAuthHeaderPresent(RequestDetails theRequest) {
 		String token = theRequest.getHeader(HttpHeaders.AUTHORIZATION);
-		return (!StringUtils.isEmpty(token));
+		return (!StringUtils.isEmpty(token) && token.toUpperCase().contains(BASIC_AUTH_TOKEN_PREFIX));
 	}
 	
 	private Boolean isApiKeyEnabled() {
@@ -172,8 +185,22 @@ public class CustomAuthorizationInterceptor extends AuthorizationInterceptor {
 		logger.info("Authorization failure - invalid X-API-KEY header");
 		return denyAll();
 	}
+	
+	private List<IAuthRule> authorizeBasicAuth(RequestDetails theRequest) {
+		String basicAuthToken = theRequest.getHeader(HttpHeaders.AUTHORIZATION);
+		if (StringUtils.isEmpty(basicAuthToken)) {
+			logger.info("Authorization failure - missing authorization header");
+			return denyAll();
+		}
+		basicAuthToken = basicAuthToken.substring(BASIC_AUTH_TOKEN_PREFIX.length());
+		if (basicAuthHelper.isValid(BASIC_AUTH_USERNAME, BASIC_AUTH_PASS, basicAuthToken)) {
+			return allowAll();
+		}
+		logger.info("Authorization failure - invalid credentials");
+		return denyAll();
+	}
 
 	public static String getTokenPrefix() {
-		return TOKEN_PREFIX;
+		return OAUTH_TOKEN_PREFIX;
 	}
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomAuthorizationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomAuthorizationInterceptor.java
@@ -51,7 +51,7 @@ public class CustomAuthorizationInterceptor extends AuthorizationInterceptor {
 			}
 
 			if (!isOAuthEnabled() && !isApiKeyEnabled() && !isBasicAuthEnabled()) {
-				logger.warn("APIKEY, BasicAuth and OAuth2 authentication are disabled");
+				logger.warn("APIKEY, basicAuth and OAuth2 authentication are disabled");
 				return allowAll();
 			}
 
@@ -65,7 +65,7 @@ public class CustomAuthorizationInterceptor extends AuthorizationInterceptor {
 				return authorizeApiKey(theRequest);
 			}
 			if (isBasicAuthEnabled() && isBasicAuthHeaderPresent(theRequest)) {
-				logger.info("Auhorizing via BasicAuth");
+				logger.info("Auhorizing via basic auth");
 				return authorizeBasicAuth(theRequest);
 			}
 		} catch (Exception e) {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomAuthorizationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomAuthorizationInterceptor.java
@@ -3,6 +3,7 @@ package ca.uhn.fhir.jpa.starter;
 import java.security.PublicKey;
 import java.util.List;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.hl7.fhir.r4.model.IdType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -154,7 +155,13 @@ public class CustomAuthorizationInterceptor extends AuthorizationInterceptor {
 	}
 	
 	private Boolean isBasicAuthEnabled() {
-		return ((BASIC_AUTH_ENABLED != null) && Boolean.parseBoolean(BASIC_AUTH_ENABLED));
+		if ((BASIC_AUTH_ENABLED != null) && Boolean.parseBoolean(BASIC_AUTH_ENABLED)) {
+			if (ObjectUtils.isEmpty(BASIC_AUTH_USERNAME) || ObjectUtils.isEmpty(BASIC_AUTH_PASS)) {
+				logger.warn("Using basic auth without setting username and password");
+			}
+			return true;
+		}
+		return false;
 	}
 	
 	private Boolean isBasicAuthHeaderPresent(RequestDetails theRequest) {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomSearchNarrowingInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomSearchNarrowingInterceptor.java
@@ -25,12 +25,14 @@ public class CustomSearchNarrowingInterceptor extends SearchNarrowingInterceptor
   }
 
   private String getPatientFromToken(RequestDetails theRequestDetails) {
-    String token = theRequestDetails.getHeader("Authorization");
-    if (token != null) {
-      token = token.substring(CustomAuthorizationInterceptor.getTokenPrefix().length());
-      DecodedJWT jwt = JWT.decode(token);
-      String patRefId = oAuth2Helper.getPatientReferenceFromToken(jwt, OAUTH_CLAIM_NAME);
-      return patRefId;
+    if (oAuth2Helper.isOAuthHeaderPresent(theRequestDetails)) {      
+      String token = theRequestDetails.getHeader("Authorization");
+      if (token != null) {
+        token = token.substring(CustomAuthorizationInterceptor.getTokenPrefix().length());
+        DecodedJWT jwt = JWT.decode(token);
+        String patRefId = oAuth2Helper.getPatientReferenceFromToken(jwt, OAUTH_CLAIM_NAME);
+        return patRefId;
+      }
     }
     return null;
   }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/OAuth2Helper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/OAuth2Helper.java
@@ -10,17 +10,17 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
-
 import org.apache.commons.lang3.ObjectUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
-
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
@@ -30,7 +30,7 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.context.RuntimeSearchParam;
-import ca.uhn.fhir.rest.server.provider.ProviderConstants;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
 
 public class OAuth2Helper {
 	private static final Logger logger = LoggerFactory.getLogger(OAuth2Helper.class);
@@ -149,5 +149,10 @@ public class OAuth2Helper {
     Claim claim = jwt.getClaim("azp");
     String azp = claim.asString();
     return azp.equals(oauthClientId);
+  }
+  
+  public boolean isOAuthHeaderPresent(RequestDetails theRequest) {
+    String token = theRequest.getHeader(HttpHeaders.AUTHORIZATION);
+    return (!StringUtils.isEmpty(token) && token.toUpperCase().contains(CustomAuthorizationInterceptor.getTokenPrefix()));
   }
 }


### PR DESCRIPTION
Added basic auth feature support to fhir server.
We use `BASIC_AUTH_ENABLED` environment variable to determine whether basic auth is enabled or not.
Also, username and password are passed as environment variables `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASS` respectively.