### PR TITLE
Mitigate log4j vulnerablity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,27 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                	<groupId>ca.uhn.hapi.fhir</groupId>
+                	<artifactId>hapi-fhir-elasticsearch-6</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+        	<groupId>ca.uhn.hapi.fhir</groupId>
+        	<artifactId>hapi-fhir-elasticsearch-6</artifactId>
+        	<version>5.2.0</version>
+        	<exclusions>
+        		<exclusion>
+        			<groupId>org.apache.logging.log4j</groupId>
+        			<artifactId>log4j-api</artifactId>
+        		</exclusion>
+        	</exclusions>
+        </dependency>
+        <dependency>
+        	<groupId>org.apache.logging.log4j</groupId>
+        	<artifactId>log4j-api</artifactId>
+        	<version>2.16.0</version>
         </dependency>
         <!-- This dependency includes the JPA EMPI Server -->
         <dependency>
@@ -528,5 +548,24 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+    <id>owasp-dependency-check</id>
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.owasp</groupId>
+          <artifactId>dependency-check-maven</artifactId>
+          <version>6.2.2</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+  </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -548,24 +548,5 @@
                 </dependency>
             </dependencies>
         </profile>
-        <profile>
-    <id>owasp-dependency-check</id>
-    <build>
-      <plugins>
-        <plugin>
-          <groupId>org.owasp</groupId>
-          <artifactId>dependency-check-maven</artifactId>
-          <version>6.2.2</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </build>
-  </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Mitigated log4j vulnerablity.
1. Before mitigation
![Screenshot from 2021-12-15 17-57-22](https://user-images.githubusercontent.com/20473487/146189316-b1b9c1ba-fe43-4aad-984d-82e0c55632d7.png)
2. After mitigation
![Screenshot from 2021-12-15 17-57-40](https://user-images.githubusercontent.com/20473487/146189383-c9728a75-6f10-4617-ae01-be18a17a9685.png)


