### PR TITLE
Updated dockerfile to use user dir path for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 FROM maven:3.8.2-jdk-11-slim as build-hapi
-WORKDIR /tmp/hapi-fhir-jpaserver-starter
+WORKDIR /usr/src/app/hapi-fhir-jpaserver-starter
 
 COPY pom.xml .
 COPY server.xml .
 RUN mvn -ntp dependency:go-offline
 
-COPY src/ /tmp/hapi-fhir-jpaserver-starter/src/
+COPY src/ /usr/src/app/hapi-fhir-jpaserver-starter/src/
 RUN mvn clean install -DskipTests
 
 FROM build-hapi AS build-distroless
 RUN mvn package spring-boot:repackage -Pboot
 RUN mkdir /app && \
-    cp /tmp/hapi-fhir-jpaserver-starter/target/ROOT.war /app/main.war
+    cp /usr/src/app/hapi-fhir-jpaserver-starter/target/ROOT.war /app/main.war
 
 FROM gcr.io/distroless/java-debian11:11 AS release-distroless
 COPY --chown=nonroot:nonroot --from=build-distroless /app /app
@@ -25,7 +25,7 @@ CMD ["/app/main.war"]
 FROM tomcat:9.0.53-jdk11-openjdk-slim-bullseye
 
 RUN mkdir -p /data/hapi/lucenefiles && chmod 775 /data/hapi/lucenefiles
-COPY --from=build-hapi /tmp/hapi-fhir-jpaserver-starter/target/*.war /usr/local/tomcat/webapps/
+COPY --from=build-hapi /usr/src/app/hapi-fhir-jpaserver-starter/target/*.war /usr/local/tomcat/webapps/
 
 COPY catalina.properties /usr/local/tomcat/conf/catalina.properties
 COPY server.xml /usr/local/tomcat/conf/server.xml


### PR DESCRIPTION
- Updated dockerfile to use /usr/src/app path instead of /tmp to prevent threadstack alerts
- Tested by building and running docker image locally