### PR TITLE
Updated hapi-fhir dependency version to 6.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-        <version>6.2.4</version>
+        <version>6.2.5</version>
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>


### PR DESCRIPTION
- Updated dependency version for `hapi-fhir` from `6.2.4` to `6.2.5`
- Tested locally by running the app and performing tests
- Run integration tests locally against the new code.