### PR TITLE
Changes logging to be in JSON format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,8 @@
         <java.version>11</java.version>
         <logback-classic.version>1.2.11</logback-classic.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
+        <logstash-logback-encoder.version>7.2</logstash-logback-encoder.version>
+        <jackson.version>2.14.1</jackson.version>
     </properties>
 
     <prerequisites>
@@ -64,6 +66,18 @@
         <dependency>
           <groupId>com.microsoft.sqlserver</groupId>
           <artifactId>mssql-jdbc</artifactId>
+        </dependency>
+        
+        <!-- Required for Json Logging -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>${logstash-logback-encoder.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
 
         <!-- Needed for Email subscriptions -->

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,11 +1,12 @@
 <configuration scan="true" scanPeriod="30 seconds">
 
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-		<filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-			<level>INFO</level>
-		</filter>
-		<encoder>
-			<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%file:%line] %msg%n</pattern>
+		<encoder class="net.logstash.logback.encoder.LogstashEncoder">
+			<fieldNames>
+				<timestamp>[ignore]</timestamp>
+				<version>[ignore]</version>
+				<levelValue>[ignore]</levelValue>
+			</fieldNames>
 		</encoder>
 	</appender>
 


### PR DESCRIPTION
- Provided support for JSON logging using logstash library.
- Tested by running the project using docker locally.
- After the changes logs are appearing as below.
`{"message":"Starting scheduler hapi-fhir-jpa-scheduler-clustered","logger_name":"ca.uhn.fhir.jpa.sched.BaseHapiScheduler","thread_name":"main","level":"INFO"}
{"message":"Scheduler hapi-fhir-jpa-scheduler_$_NON_CLUSTERED started.","logger_name":"org.quartz.core.QuartzScheduler","thread_name":"main","level":"INFO"}`