### PR TITLE
Changes the spring-banner mode to log

### DIFF
--- a/src/main/resources/application-custom.yaml
+++ b/src/main/resources/application-custom.yaml
@@ -9,6 +9,7 @@ spring:
   main:
     allow-circular-references: true
     #allow-bean-definition-overriding: true
+    banner-mode: "log"
   batch.job.enabled: false
   flyway:
     enabled: false


### PR DESCRIPTION
- Changed the spring-banner mode to log to override its default value console.
- Updated the application-custom.yaml file to add a property `banner-mode: "log"` 
- Before the change logs were appearing as below.
![image](https://github.com/elimuinformatics/hapi-fhir-jpaserver-starter/assets/20473487/90377384-2239-4f61-81d2-e47b045d9db5)

- After the changes.
![image](https://github.com/elimuinformatics/hapi-fhir-jpaserver-starter/assets/20473487/fd2db4aa-f239-4de2-8e10-823b647187ae)
