### PR TITLE
Allows configuration of auth via yaml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,15 @@ services:
       - "8080:8080"
     environment:
       fhir_version: 'R4'
-      hapi.fhir.server_address: 'http://localhost:8080/baseR4'
       spring.datasource.url: 'jdbc:postgresql://hapi-fhir-postgres:5432/hapi'
       spring.datasource.username: admin
       spring.datasource.password: admin
       spring.datasource.driverClassName: org.postgresql.Driver
       spring.jpa.properties.hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
+      spring.config.location: classpath:/application-custom.yaml
+      reuse_cached_search_results_millis: 0
+      subscription.resthook.enabled: true
+      subscription.websocket.enabled: true
       BASIC_AUTH_ENABLED: false
       BASIC_AUTH_USERNAME: "admin"
       BASIC_AUTH_PASSWORD: "admin"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "8080:8080"
     environment:
       fhir_version: 'R4'
-      # hapi.fhir.server_address: 'http://localhost:8080/baseR4'
+      hapi.fhir.server_address: 'http://localhost:8080/baseR4'
       spring.datasource.url: 'jdbc:postgresql://hapi-fhir-postgres:5432/hapi'
       spring.datasource.username: admin
       spring.datasource.password: admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,19 +8,26 @@ services:
       - "8080:8080"
     environment:
       fhir_version: 'R4'
-      hapi.fhir.server_address: 'http://localhost:8080/baseR4'
+      # hapi.fhir.server_address: 'http://localhost:8080/baseR4'
       spring.datasource.url: 'jdbc:postgresql://hapi-fhir-postgres:5432/hapi'
       spring.datasource.username: admin
       spring.datasource.password: admin
       spring.datasource.driverClassName: org.postgresql.Driver
       spring.jpa.properties.hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
+      BASIC_AUTH_ENABLED: false
+      BASIC_AUTH_USERNAME: "admin"
+      BASIC_AUTH_PASSWORD: "admin"
       OAUTH_ENABLED: true
+      OAUTH_CLIENT_ID: fhir4-api
+      OAUTH_USER_ROLE: fhir4-user
+      OAUTH_ADMIN_ROLE: fhir4-admin
       OAUTH_ISSUER: https://auth-internal.elimuinformatics.com/auth/realms/product
       OAUTH_JWKS_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/protocol/openid-connect/certs
       OAUTH_AUTHORIZATION_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/protocol/openid-connect/auth
       OAUTH_TOKEN_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/protocol/openid-connect/token
       OAUTH_INTROSPECTION_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/protocol/openid-connect/token/introspect
       OAUTH_REVOCATION_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/protocol/openid-connect/revoke
+      OAUTH_MANAGE_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/account
   hapi-fhir-postgres:
     image: postgres:13-alpine
     container_name: hapi-fhir-postgres

--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -66,6 +66,8 @@ public class AppProperties {
 
   private Validation validation = new Validation();
   private Map<String, Tester> tester = null;
+  private Basic_auth basic_auth = new Basic_auth();
+  private Apikey apikey = new Apikey();
   private Oauth oauth = new Oauth();
   private Logger logger = new Logger();
   private Subscription subscription = new Subscription();
@@ -231,6 +233,22 @@ public class AppProperties {
 
   public void setSupported_resource_types(List<String> supported_resource_types) {
     this.supported_resource_types = supported_resource_types;
+  }
+
+  public Basic_auth getBasic_auth() {
+    return basic_auth;
+  }
+
+  public void setBasic_auth(Basic_auth basic_auth) {
+    this.basic_auth = basic_auth;
+  }
+
+  public Apikey getApikey() {
+    return apikey;
+  }
+
+  public void setApikey(Apikey apikey) {
+    this.apikey = apikey;
   }
 
   public Oauth getOauth() {
@@ -605,6 +623,57 @@ public class AppProperties {
     }
 
 
+  }
+
+  public static class Basic_auth {
+    private Boolean enabled = false;
+    private String username;
+    private String password;
+
+    public Boolean getEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public String getUsername() {
+      return username;
+    }
+
+    public void setUsername(String username) {
+      this.username = username;
+    }
+
+    public String getPassword() {
+      return password;
+    }
+
+    public void setPassword(String password) {
+      this.password = password;
+    }
+  }
+
+  public static class Apikey {
+    private Boolean enabled = false;
+    private String key;
+
+    public Boolean getEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public void setKey(String key) {
+      this.key = key;
+    }
   }
 
   public static class Oauth {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/BasicAuthHelper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/BasicAuthHelper.java
@@ -1,12 +1,27 @@
 package ca.uhn.fhir.jpa.starter;
 
 import java.util.Base64;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.http.HttpHeaders;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
 
 public class BasicAuthHelper {
+
+  private static final String AUTHORIZATION_PREFIX = "BASIC ";
+
+  public static String getCredentials(RequestDetails theRequest) {
+    String auth = theRequest.getHeader(HttpHeaders.AUTHORIZATION);
+    return auth.substring(AUTHORIZATION_PREFIX.length());
+  }
 
   public boolean isValid(String basicAuthUsername, String basicAuthPass, String basicAuthToken) {
     String unEncodedUsernamePass = basicAuthUsername + ":" + basicAuthPass;
     String encodedUsernamePass = Base64.getEncoder().encodeToString(unEncodedUsernamePass.getBytes());
     return encodedUsernamePass.equals(basicAuthToken);
   }
+
+	public static boolean isBasicAuthHeaderPresent(RequestDetails theRequest) {
+		String auth = theRequest.getHeader(HttpHeaders.AUTHORIZATION);
+		return (!ObjectUtils.isEmpty(auth) && auth.toUpperCase().startsWith(AUTHORIZATION_PREFIX));
+	}
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomConsentService.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomConsentService.java
@@ -135,8 +135,7 @@ public class CustomConsentService implements IConsentService {
   }
 
   private String getPatientFromToken(RequestDetails theRequestDetails) {
-    String token = theRequestDetails.getHeader("Authorization");
-    token = token.substring(CustomAuthorizationInterceptor.getTokenPrefix().length());
+    String token = OAuth2Helper.getToken(theRequestDetails);
     DecodedJWT jwt = JWT.decode(token);
     String patRefId = oAuth2Helper.getPatientReferenceFromToken(jwt, OAUTH_CLAIM_NAME);
     return patRefId;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/CustomSearchNarrowingInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/CustomSearchNarrowingInterceptor.java
@@ -11,7 +11,7 @@ import ca.uhn.fhir.rest.server.interceptor.auth.SearchNarrowingInterceptor;
 public class CustomSearchNarrowingInterceptor extends SearchNarrowingInterceptor {
 
   private static final String OAUTH_CLAIM_NAME = "patient";
-  
+
   private OAuth2Helper oAuth2Helper = new OAuth2Helper();
 
   @Override
@@ -25,10 +25,9 @@ public class CustomSearchNarrowingInterceptor extends SearchNarrowingInterceptor
   }
 
   private String getPatientFromToken(RequestDetails theRequestDetails) {
-    if (oAuth2Helper.isOAuthHeaderPresent(theRequestDetails)) {      
-      String token = theRequestDetails.getHeader("Authorization");
+    if (oAuth2Helper.isOAuthHeaderPresent(theRequestDetails)) {
+      String token = OAuth2Helper.getToken(theRequestDetails);
       if (token != null) {
-        token = token.substring(CustomAuthorizationInterceptor.getTokenPrefix().length());
         DecodedJWT jwt = JWT.decode(token);
         String patRefId = oAuth2Helper.getPatientReferenceFromToken(jwt, OAUTH_CLAIM_NAME);
         return patRefId;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -76,6 +76,7 @@ public class FhirServerConfigCommon {
         ourLog.info("Indexed on contained resource enabled");
     }
 
+    ourLog.info("Server configured to {} Basic authentication", appProperties.getBasic_auth().getEnabled() ? "enable" : "disable");
     ourLog.info("Server configured to {} OAuth2 authentication", appProperties.getOauth().getEnabled() ? "enable" : "disable");
   }
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -411,15 +411,19 @@ public class StarterJpaConfig {
 			fhirServer.setTenantIdentificationStrategy(new UrlBaseTenantIdentificationStrategy());
 			fhirServer.registerProviders(partitionManagementProvider);
 		}
-		
+
 		// Support for OAuth2, Basic, and API_KEY authentication
 		if (appProperties.getOauth().getEnabled()) {
 			fhirServer.registerInterceptor(new CapabilityStatementCustomizer(appProperties));
 			fhirServer.registerInterceptor(new CustomSearchNarrowingInterceptor());
 			fhirServer.registerInterceptor(new ConsentInterceptor(new CustomConsentService(daoRegistry)));
-			fhirServer.registerInterceptor(new CustomAuthorizationInterceptor());
 		}
-	
+		if (appProperties.getBasic_auth().getEnabled()
+				|| appProperties.getOauth().getEnabled()
+				|| appProperties.getApikey().getEnabled()) {
+			fhirServer.registerInterceptor(new CustomAuthorizationInterceptor(appProperties));
+		}
+
 		repositoryValidatingInterceptor.ifPresent(fhirServer::registerInterceptor);
 
 		// register custom interceptors

--- a/src/main/resources/application-custom.yaml
+++ b/src/main/resources/application-custom.yaml
@@ -148,6 +148,8 @@ hapi:
 
     basic_auth:
       enabled: ${BASIC_AUTH_ENABLED:false}
+      username: ${BASIC_AUTH_USERNAME}
+      password: ${BASIC_AUTH_PASSWORD}
 
 #    logger:
     #      error_format: 'ERROR - ${requestVerb} ${requestUrl}'

--- a/src/main/resources/application-custom.yaml
+++ b/src/main/resources/application-custom.yaml
@@ -134,6 +134,9 @@ hapi:
 
     oauth:
       enabled: ${OAUTH_ENABLED:false}
+      client_id: ${OAUTH_CLIENT_ID}
+      user_role: ${OAUTH_USER_ROLE}
+      admin_role: ${OAUTH_ADMIN_ROLE}
       issuer: ${OAUTH_ISSUER}
       jwks_url: ${OAUTH_JWKS_URL}
       authorization_url: ${OAUTH_AUTHORIZATION_URL}
@@ -142,6 +145,9 @@ hapi:
       introspection_url: ${OAUTH_INTROSPECTION_URL}
       revocation_url: ${OAUTH_REVOCATION_URL}
       manage_url: ${OAUTH_MANAGE_URL}
+
+    basic_auth:
+      enabled: ${BASIC_AUTH_ENABLED:false}
 
 #    logger:
     #      error_format: 'ERROR - ${requestVerb} ${requestUrl}'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -154,6 +154,9 @@ hapi:
 
     oauth:
       enabled: ${OAUTH_ENABLED:false}
+      client_id: ${OAUTH_CLIENT_ID}
+      user_role: ${OAUTH_USER_ROLE}
+      admin_role: ${OAUTH_ADMIN_ROLE}
       issuer: ${OAUTH_ISSUER}
       jwks_url: ${OAUTH_JWKS_URL}
       authorization_url: ${OAUTH_AUTHORIZATION_URL}
@@ -162,6 +165,11 @@ hapi:
       introspection_url: ${OAUTH_INTROSPECTION_URL}
       revocation_url: ${OAUTH_REVOCATION_URL}
       manage_url: ${OAUTH_MANAGE_URL}
+
+    basic_auth:
+      enabled: ${BASIC_AUTH_ENABLED:false}
+      username: ${BASIC_AUTH_USERNAME}
+      password: ${BASIC_AUTH_PASSWORD}
 
     #    logger:
     #      error_format: 'ERROR - ${requestVerb} ${requestUrl}'


### PR DESCRIPTION
## Overview

- Replaced direct use of environment variables w/ configuration from the application.yaml (or alternate yaml) file. For backwards compatibility, I have the yaml file using the environment variables.

## How it was tested

- Ran locally w/ Basic Auth configured and tested w/ and w/o correct credentials
- Ran locally w/ OAuth2 configured and tested w/ and w/o correct credentials
- Ran locally w/ both configured and tested w/ and w/o correct credentials
- Ran locally w/ OAuth2 configured and ran the Postman authentication tests

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
