### PR TITLE
Increased the db connection timeout

### DIFF
--- a/src/main/resources/application-custom.yaml
+++ b/src/main/resources/application-custom.yaml
@@ -25,6 +25,9 @@ spring:
     # database connection pool size
     hikari:
       maximum-pool-size: 25
+      connection-test-query: SELECT 1
+      connection-timeout: 60000
+      
   jpa:
     properties:
       hibernate.format_sql: false


### PR DESCRIPTION
- **connection-test-query**: The connection-test-query is a configuration property in Hikari that allows us to specify a SQL query that will be executed each time a connection is taken from the pool to ensure the connection is still valid and usable. If the test query fails to execute or returns an error, the connection is considered invalid, and Hikari will remove it from the pool and try to create a new one.
- **connection-timeout**: Earlier it was 30sec now increased it to 60sec to wait before throwing connection.
- Detail documentation can be found here: https://github.com/brettwooldridge/HikariCP#gear-configuration-knobs-baby
