### PR TITLE
Updates smart configuration implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,23 +282,8 @@ You can use a custom property file that utilizes environment variables for many 
 
 ```bash
 ./build-docker-image.sh && docker run -p 8080:8080 \
--e APIKEY=<apikey> \
--e APIKEY_ENABLED=<true/false> \
--e datasource.driver=<datasource_driver> \
--e datasource.password=<datasource_password> \
--e datasource.url=<jdbc_url> \
--e datasource.username=<datasource_password> \
--e fhir_version=<DSTU2/DSTU3/R4> \
--e hapi.fhir.server_address=<server_address>/fhir/ \
--e hibernate.dialect=<hibernate_dialect> \
--e OAUTH_ENABLED=<true/false> \
--e OAUTH_URL=<oauth_server_url> \
--e reuse_cached_search_results_millis=<milliseconds_value_to_reuse_cached_search_results> \
--e spring.config.location='<classpath:/application-custom.yaml>' \
--e subscription.resthook.enabled=<true/false> \
--e subscription.websocket.enabled=<true/false> \
--e url_pattern=</fhir/*> \
-hapi-fhir/hapi-fhir-jpaserver-starter:latest
+  -e spring.config.location='<classpath:/application-custom.yaml>' \
+  hapi-fhir/hapi-fhir-jpaserver-starter:latest
 ```
 
 ## Configurations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,13 +23,16 @@ services:
       OAUTH_CLIENT_ID: fhir4-api
       OAUTH_USER_ROLE: fhir4-user
       OAUTH_ADMIN_ROLE: fhir4-admin
-      OAUTH_ISSUER: https://auth-internal.elimuinformatics.com/auth/realms/product
       OAUTH_JWKS_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/protocol/openid-connect/certs
-      OAUTH_AUTHORIZATION_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/protocol/openid-connect/auth
       OAUTH_TOKEN_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/protocol/openid-connect/token
-      OAUTH_INTROSPECTION_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/protocol/openid-connect/token/introspect
-      OAUTH_REVOCATION_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/protocol/openid-connect/revoke
       OAUTH_MANAGE_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/account
+      SMART_ISSUER: https://auth-internal.elimuinformatics.com/auth/realms/product
+      SMART_JWKS_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/protocol/openid-connect/certs
+      SMART_AUTHORIZATION_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/protocol/openid-connect/auth
+      SMART_TOKEN_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/protocol/openid-connect/token
+      SMART_INTROSPECTION_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/protocol/openid-connect/token/introspect
+      SMART_REVOCATION_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/protocol/openid-connect/revoke
+      SMART_MANAGE_URL: https://auth-internal.elimuinformatics.com/auth/realms/product/account
   hapi-fhir-postgres:
     image: postgres:13-alpine
     container_name: hapi-fhir-postgres

--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -56,6 +56,7 @@ public class AppProperties {
   private Integer defer_indexing_for_codesystems_of_size = 100;
   private Long retain_cached_searches_mins = 60L;
   private Long reuse_cached_search_results_millis = 60000L;
+  private String server_path = "/fhir";
   private String server_address = null;
   private EncodingEnum default_encoding = EncodingEnum.JSON;
   private FhirVersionEnum fhir_version = FhirVersionEnum.R4;
@@ -68,6 +69,7 @@ public class AppProperties {
   private Map<String, Tester> tester = null;
   private Apikey apikey = new Apikey();
   private Oauth oauth = new Oauth();
+  private Smart smart = new Smart();
   private Logger logger = new Logger();
   private Subscription subscription = new Subscription();
   private Cors cors = null;
@@ -194,6 +196,14 @@ public class AppProperties {
     this.allowed_bundle_types = allowed_bundle_types;
   }
 
+  public String getServer_path() {
+    return server_path;
+  }
+
+  public void setServer_path(String server_path) {
+    this.server_path = server_path;
+  }
+
   public String getServer_address() {
     return server_address;
   }
@@ -248,6 +258,14 @@ public class AppProperties {
 
   public void setOauth(Oauth oauth) {
     this.oauth = oauth;
+  }
+
+  public Smart getSmart() {
+    return smart;
+  }
+
+  public void setSmart(Smart smart) {
+    this.smart = smart;
   }
 
 	public Logger getLogger() {
@@ -639,17 +657,12 @@ public class AppProperties {
 
   public static class Oauth {
     private Boolean enabled = false;
-    private String issuer;
     private String jwks_url;
-    private String authorization_url;
-    private String grant_types_supported;
     private String token_url;
     private String manage_url;
     private String client_id;
     private String user_role;
     private String admin_role;
-    private String introspection_url;
-    private String revocation_url;
 
     public Boolean getEnabled() {
       return enabled;
@@ -658,6 +671,65 @@ public class AppProperties {
     public void setEnabled(Boolean enabled) {
       this.enabled = enabled;
     }
+
+    public String getJwks_url() {
+      return jwks_url;
+    }
+
+    public void setJwks_url(String jwks_url) {
+      this.jwks_url = jwks_url;
+    }
+
+    public String getToken_url() {
+      return token_url;
+    }
+
+    public void setToken_url(String token_url) {
+      this.token_url = token_url;
+    }
+
+    public String getManage_url() {
+      return manage_url;
+    }
+
+    public void setManage_url(String manage_url) {
+      this.manage_url = manage_url;
+    }
+
+    public String getClient_id() {
+      return client_id;
+    }
+
+    public void setClient_id(String client_id) {
+      this.client_id = client_id;
+    }
+
+    public String getUser_role() {
+      return user_role;
+    }
+
+    public void setUser_role(String user_role) {
+      this.user_role = user_role;
+    }
+
+    public String getAdmin_role() {
+      return admin_role;
+    }
+
+    public void setAdmin_role(String admin_role) {
+      this.admin_role = admin_role;
+    }
+  }
+
+  public static class Smart {
+    private String issuer;
+    private String jwks_url;
+    private String authorization_url;
+    private String grant_types_supported;
+    private String token_url;
+    private String manage_url;
+    private String introspection_url;
+    private String revocation_url;
 
     public String getIssuer() {
       return issuer;
@@ -705,30 +777,6 @@ public class AppProperties {
 
     public void setManage_url(String manage_url) {
       this.manage_url = manage_url;
-    }
-
-    public String getClient_id() {
-      return client_id;
-    }
-
-    public void setClient_id(String client_id) {
-      this.client_id = client_id;
-    }
-
-    public String getUser_role() {
-      return user_role;
-    }
-
-    public void setUser_role(String user_role) {
-      this.user_role = user_role;
-    }
-
-    public String getAdmin_role() {
-      return admin_role;
-    }
-
-    public void setAdmin_role(String admin_role) {
-      this.admin_role = admin_role;
     }
 
     public String getIntrospection_url() {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/util/WellknownEndpointHelper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/util/WellknownEndpointHelper.java
@@ -29,15 +29,15 @@ public class WellknownEndpointHelper {
    */
   public static String getWellKnownJson(AppProperties appProperties) {
     return new JSONObject()
-      .put(ISSUER_KEY, appProperties.getOauth().getIssuer())
-      .put(JWKS_ENDPOINT_KEY, appProperties.getOauth().getJwks_url())
-      .put(AUTHORIZATION_ENDPOINT_KEY, appProperties.getOauth().getAuthorization_url())
-      .put(GRANT_TYPES_SUPPORTED_KEY, appProperties.getOauth().getGrant_types_supported())
-      .put(TOKEN_ENDPOINT_KEY, appProperties.getOauth().getToken_url())
+      .put(ISSUER_KEY, appProperties.getSmart().getIssuer())
+      .put(JWKS_ENDPOINT_KEY, appProperties.getSmart().getJwks_url())
+      .put(AUTHORIZATION_ENDPOINT_KEY, appProperties.getSmart().getAuthorization_url())
+      .put(GRANT_TYPES_SUPPORTED_KEY, appProperties.getSmart().getGrant_types_supported())
+      .put(TOKEN_ENDPOINT_KEY, appProperties.getSmart().getToken_url())
       .put(SCOPES_SUPPORTED_KEY, getScopesSupported())
       .put(RESPONSE_TYPES_SUPPORTED_KEY, getResponseTypesSupported())
-      .putOpt(INTROSPECTION_ENDPOINT_KEY, appProperties.getOauth().getIntrospection_url())
-      .putOpt(REVOCATION_ENDPOINT_KEY, appProperties.getOauth().getRevocation_url())
+      .putOpt(INTROSPECTION_ENDPOINT_KEY, appProperties.getSmart().getIntrospection_url())
+      .putOpt(REVOCATION_ENDPOINT_KEY, appProperties.getSmart().getRevocation_url())
       .put(CAPABILITIES_KEY, getCapabilities())
       .put(CODE_CHALLENGE_METHODS_SUPPORTED_KEY, getCodeChallengeMethodsSupported())
       .toString(2);

--- a/src/main/resources/application-custom.yaml
+++ b/src/main/resources/application-custom.yaml
@@ -62,6 +62,7 @@ hapi:
     ### alternatively, it may be set using the X-Forwarded-Proto header.
     #   use_apache_address_strategy_https: false
     ### enable to set the Server URL
+    #    server_path: /baseR4
     #    server_address: http://hapi.fhir.org/baseR4
     #    defer_indexing_for_codesystems_of_size: 101
     #    install_transitive_ig_dependencies: true
@@ -137,20 +138,25 @@ hapi:
       client_id: ${OAUTH_CLIENT_ID}
       user_role: ${OAUTH_USER_ROLE}
       admin_role: ${OAUTH_ADMIN_ROLE}
-      issuer: ${OAUTH_ISSUER}
       jwks_url: ${OAUTH_JWKS_URL}
-      authorization_url: ${OAUTH_AUTHORIZATION_URL}
-      grant_types_supported: ${OAUTH_GRANT_TYPES_SUPPORTED:authorization_code}
       token_url: ${OAUTH_TOKEN_URL}
-      introspection_url: ${OAUTH_INTROSPECTION_URL}
-      revocation_url: ${OAUTH_REVOCATION_URL}
       manage_url: ${OAUTH_MANAGE_URL}
 
     apikey:
       enabled: ${APIKEY_ENABLED:false}
       key: ${APIKEY}
 
-#    logger:
+    smart:
+      issuer: ${SMART_ISSUER}
+      jwks_url: ${SMART_JWKS_URL}
+      authorization_url: ${SMART_AUTHORIZATION_URL}
+      grant_types_supported: ${SMART_GRANT_TYPES_SUPPORTED:authorization_code}
+      token_url: ${SMART_TOKEN_URL}
+      introspection_url: ${SMART_INTROSPECTION_URL}
+      revocation_url: ${SMART_REVOCATION_URL}
+      manage_url: ${SMART_MANAGE_URL}
+
+    #    logger:
     #      error_format: 'ERROR - ${requestVerb} ${requestUrl}'
     #      format: >-
     #        Path[${servletPath}] Source[${requestHeader.x-forwarded-for}]

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -68,6 +68,7 @@ hapi:
     ### the deepest folder level will be used. E.g. - if you put file:/foo/bar/bazz as value then the files are resolved under /static/bazz/**
     #staticLocation: file:/foo/bar/bazz
     ### enable to set the Server URL
+    #    server_path: /baseR4
     #    server_address: http://hapi.fhir.org/baseR4
     #    defer_indexing_for_codesystems_of_size: 101
     #    install_transitive_ig_dependencies: true
@@ -157,18 +158,23 @@ hapi:
       client_id: ${OAUTH_CLIENT_ID}
       user_role: ${OAUTH_USER_ROLE}
       admin_role: ${OAUTH_ADMIN_ROLE}
-      issuer: ${OAUTH_ISSUER}
       jwks_url: ${OAUTH_JWKS_URL}
-      authorization_url: ${OAUTH_AUTHORIZATION_URL}
-      grant_types_supported: ${OAUTH_GRANT_TYPES_SUPPORTED:authorization_code}
       token_url: ${OAUTH_TOKEN_URL}
-      introspection_url: ${OAUTH_INTROSPECTION_URL}
-      revocation_url: ${OAUTH_REVOCATION_URL}
       manage_url: ${OAUTH_MANAGE_URL}
 
     apikey:
       enabled: ${APIKEY_ENABLED:false}
       key: ${APIKEY}
+
+    smart:
+      issuer: ${SMART_ISSUER}
+      jwks_url: ${SMART_JWKS_URL}
+      authorization_url: ${SMART_AUTHORIZATION_URL}
+      grant_types_supported: ${SMART_GRANT_TYPES_SUPPORTED:authorization_code}
+      token_url: ${SMART_TOKEN_URL}
+      introspection_url: ${SMART_INTROSPECTION_URL}
+      revocation_url: ${SMART_REVOCATION_URL}
+      manage_url: ${SMART_MANAGE_URL}
 
     #    logger:
     #      error_format: 'ERROR - ${requestVerb} ${requestUrl}'


### PR DESCRIPTION
## Overview

Updates the `./well-known/smart-configuration` implementation to separate the use of OAuth properties from the ones needed for the smart-configuration. This is needed in some rare cases where the smart-configuration is used by a SMART App Launcher when testing.

This also replaces the use of the `url_mapping` configuration with a new `server_path` so that the path can be used by the main servlet and the one for the smart-configuration.

## How it was tested

I tested this by building it locally, running all existing integration tests, and running many rounds of manual tests via Postman. 

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
