### PR TITLE
Smart config cors

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
@@ -13,6 +13,18 @@ import ca.uhn.fhir.jpa.subscription.match.config.WebsocketDispatcherConfig;
 import ca.uhn.fhir.jpa.subscription.submit.config.SubscriptionSubmitterConfig;
 import ca.uhn.fhir.rest.server.RestfulServer;
 import ca.uhn.fhir.rest.server.interceptor.CorsInterceptor;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.boot.SpringApplication;
@@ -27,6 +39,7 @@ import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Component;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
@@ -128,8 +141,29 @@ public class Application extends SpringBootServletInitializer {
     String serverPath = appProperties.getServer_path();
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration(serverPath + "/.well-known/*", corsInterceptor.getConfig());
-    FilterRegistrationBean filterBean = new FilterRegistrationBean(new CorsFilter(source));
+    // FilterRegistrationBean filterBean = new FilterRegistrationBean(new CorsFilter(source));
+    FilterRegistrationBean filterBean = new FilterRegistrationBean();
+    filterBean.setFilter(new SmartConfigurationFilter());
     filterBean.setOrder(0);
     return filterBean;
+  }
+
+  @Component
+  @Conditional(OnCorsPresent.class)
+  public class SmartConfigurationFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
+      HttpServletRequest request = (HttpServletRequest)req;
+      HttpServletResponse response = (HttpServletResponse)res;
+      corsInterceptor.incomingRequestPreProcessed(request, response);
+      chain.doFilter(req, res);
+    }
+
+    @Override
+    public void destroy() {}
+
+    @Override
+    public void init(FilterConfig arg0) throws ServletException {}
   }
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
@@ -141,7 +141,6 @@ public class Application extends SpringBootServletInitializer {
     String serverPath = appProperties.getServer_path();
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration(serverPath + "/.well-known/*", corsInterceptor.getConfig());
-    // FilterRegistrationBean filterBean = new FilterRegistrationBean(new CorsFilter(source));
     FilterRegistrationBean filterBean = new FilterRegistrationBean();
     filterBean.setFilter(new SmartConfigurationFilter());
     filterBean.setOrder(0);
@@ -151,7 +150,6 @@ public class Application extends SpringBootServletInitializer {
   @Component
   @Conditional(OnCorsPresent.class)
   public class SmartConfigurationFilter implements Filter {
-
     @Override
     public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
       HttpServletRequest request = (HttpServletRequest)req;


### PR DESCRIPTION
## Overview

Fix for adding CORS configuration for the `./well-known/smart-configuration` implementation. It turns out that the CORS configuration was not enough, so this adds a filter that calls the CorsInterceptor directly.

## How it was tested

I tested this by building it locally, running all existing integration tests, and running manual tests via Postman. 

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
