### PR TITLE
CustomLoggingInterceptor for X-Correlation-Id

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -46,7 +46,6 @@ import ca.uhn.fhir.jpa.starter.common.validation.IRepositoryValidationIntercepto
 import ca.uhn.fhir.jpa.starter.interceptor.CapabilityStatementCustomizer;
 import ca.uhn.fhir.jpa.starter.interceptor.CustomAuthorizationInterceptor;
 import ca.uhn.fhir.jpa.starter.interceptor.CustomConsentService;
-import ca.uhn.fhir.jpa.starter.interceptor.CustomLoggingInterceptor;
 import ca.uhn.fhir.jpa.starter.interceptor.CustomSearchNarrowingInterceptor;
 import ca.uhn.fhir.jpa.starter.ips.IpsConfigCondition;
 import ca.uhn.fhir.jpa.starter.util.EnvironmentHelper;
@@ -310,7 +309,6 @@ public class StarterJpaConfig {
 		}
 
 		fhirServer.registerInterceptor(loggingInterceptor);
-		fhirServer.registerInterceptor(new CustomLoggingInterceptor());
 
 		/*
 		 * If you are hosting this server at a specific DNS name, the server will try to

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -46,6 +46,7 @@ import ca.uhn.fhir.jpa.starter.common.validation.IRepositoryValidationIntercepto
 import ca.uhn.fhir.jpa.starter.interceptor.CapabilityStatementCustomizer;
 import ca.uhn.fhir.jpa.starter.interceptor.CustomAuthorizationInterceptor;
 import ca.uhn.fhir.jpa.starter.interceptor.CustomConsentService;
+import ca.uhn.fhir.jpa.starter.interceptor.CustomLoggingInterceptor;
 import ca.uhn.fhir.jpa.starter.interceptor.CustomSearchNarrowingInterceptor;
 import ca.uhn.fhir.jpa.starter.ips.IpsConfigCondition;
 import ca.uhn.fhir.jpa.starter.util.EnvironmentHelper;
@@ -178,18 +179,17 @@ public class StarterJpaConfig {
 	}
 
 	@Bean
-	public LoggingInterceptor loggingInterceptor(AppProperties appProperties) {
+	public CustomLoggingInterceptor loggingInterceptor(AppProperties appProperties) {
 
 		/*
 		 * Add some logging for each request
 		 */
-
-		LoggingInterceptor loggingInterceptor = new LoggingInterceptor();
-		loggingInterceptor.setLoggerName(appProperties.getLogger().getName());
-		loggingInterceptor.setMessageFormat(appProperties.getLogger().getFormat());
-		loggingInterceptor.setErrorMessageFormat(appProperties.getLogger().getError_format());
-		loggingInterceptor.setLogExceptions(appProperties.getLogger().getLog_exceptions());
-		return loggingInterceptor;
+		CustomLoggingInterceptor customLoggingInterceptor = new CustomLoggingInterceptor();
+		customLoggingInterceptor.setLoggerName(appProperties.getLogger().getName());
+		customLoggingInterceptor.setMessageFormat(appProperties.getLogger().getFormat());
+		customLoggingInterceptor.setErrorMessageFormat(appProperties.getLogger().getError_format());
+		customLoggingInterceptor.setLogExceptions(appProperties.getLogger().getLog_exceptions());
+		return customLoggingInterceptor;
 	}
 
 	@Bean("packageInstaller")
@@ -246,7 +246,7 @@ public class StarterJpaConfig {
 	}
 
 	@Bean
-	public RestfulServer restfulServer(IFhirSystemDao<?, ?> fhirSystemDao, AppProperties appProperties, DaoRegistry daoRegistry, Optional<MdmProviderLoader> mdmProviderProvider, IJpaSystemProvider jpaSystemProvider, ResourceProviderFactory resourceProviderFactory, JpaStorageSettings jpaStorageSettings, ISearchParamRegistry searchParamRegistry, IValidationSupport theValidationSupport, DatabaseBackedPagingProvider databaseBackedPagingProvider, LoggingInterceptor loggingInterceptor, Optional<TerminologyUploaderProvider> terminologyUploaderProvider, Optional<SubscriptionTriggeringProvider> subscriptionTriggeringProvider, Optional<CorsInterceptor> corsInterceptor, IInterceptorBroadcaster interceptorBroadcaster, Optional<BinaryAccessProvider> binaryAccessProvider, BinaryStorageInterceptor binaryStorageInterceptor, IValidatorModule validatorModule, Optional<GraphQLProvider> graphQLProvider, BulkDataExportProvider bulkDataExportProvider, BulkDataImportProvider bulkDataImportProvider, ValueSetOperationProvider theValueSetOperationProvider, ReindexProvider reindexProvider, PartitionManagementProvider partitionManagementProvider, Optional<RepositoryValidatingInterceptor> repositoryValidatingInterceptor, IPackageInstallerSvc packageInstallerSvc, ThreadSafeResourceDeleterSvc theThreadSafeResourceDeleterSvc, ApplicationContext appContext, Optional<IpsOperationProvider> theIpsOperationProvider) {
+	public RestfulServer restfulServer(IFhirSystemDao<?, ?> fhirSystemDao, AppProperties appProperties, DaoRegistry daoRegistry, Optional<MdmProviderLoader> mdmProviderProvider, IJpaSystemProvider jpaSystemProvider, ResourceProviderFactory resourceProviderFactory, JpaStorageSettings jpaStorageSettings, ISearchParamRegistry searchParamRegistry, IValidationSupport theValidationSupport, DatabaseBackedPagingProvider databaseBackedPagingProvider, CustomLoggingInterceptor loggingInterceptor, Optional<TerminologyUploaderProvider> terminologyUploaderProvider, Optional<SubscriptionTriggeringProvider> subscriptionTriggeringProvider, Optional<CorsInterceptor> corsInterceptor, IInterceptorBroadcaster interceptorBroadcaster, Optional<BinaryAccessProvider> binaryAccessProvider, BinaryStorageInterceptor binaryStorageInterceptor, IValidatorModule validatorModule, Optional<GraphQLProvider> graphQLProvider, BulkDataExportProvider bulkDataExportProvider, BulkDataImportProvider bulkDataImportProvider, ValueSetOperationProvider theValueSetOperationProvider, ReindexProvider reindexProvider, PartitionManagementProvider partitionManagementProvider, Optional<RepositoryValidatingInterceptor> repositoryValidatingInterceptor, IPackageInstallerSvc packageInstallerSvc, ThreadSafeResourceDeleterSvc theThreadSafeResourceDeleterSvc, ApplicationContext appContext, Optional<IpsOperationProvider> theIpsOperationProvider) {
 		RestfulServer fhirServer = new RestfulServer(fhirSystemDao.getContext());
 
 		List<String> supportedResourceTypes = appProperties.getSupported_resource_types();

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -179,17 +179,18 @@ public class StarterJpaConfig {
 	}
 
 	@Bean
-	public CustomLoggingInterceptor loggingInterceptor(AppProperties appProperties) {
+	public LoggingInterceptor loggingInterceptor(AppProperties appProperties) {
 
 		/*
 		 * Add some logging for each request
 		 */
-		CustomLoggingInterceptor customLoggingInterceptor = new CustomLoggingInterceptor();
-		customLoggingInterceptor.setLoggerName(appProperties.getLogger().getName());
-		customLoggingInterceptor.setMessageFormat(appProperties.getLogger().getFormat());
-		customLoggingInterceptor.setErrorMessageFormat(appProperties.getLogger().getError_format());
-		customLoggingInterceptor.setLogExceptions(appProperties.getLogger().getLog_exceptions());
-		return customLoggingInterceptor;
+
+		LoggingInterceptor loggingInterceptor = new LoggingInterceptor();
+		loggingInterceptor.setLoggerName(appProperties.getLogger().getName());
+		loggingInterceptor.setMessageFormat(appProperties.getLogger().getFormat());
+		loggingInterceptor.setErrorMessageFormat(appProperties.getLogger().getError_format());
+		loggingInterceptor.setLogExceptions(appProperties.getLogger().getLog_exceptions());
+		return loggingInterceptor;
 	}
 
 	@Bean("packageInstaller")
@@ -230,6 +231,7 @@ public class StarterJpaConfig {
 		config.addAllowedHeader("x-fhir-starter");
 		config.addAllowedHeader("X-Requested-With");
 		config.addAllowedHeader("Prefer");
+		config.addAllowedHeader("X-Correlation-Id");
 
 		List<String> allAllowedCORSOrigins = appProperties.getCors().getAllowed_origin();
 		allAllowedCORSOrigins.forEach(config::addAllowedOriginPattern);
@@ -246,7 +248,7 @@ public class StarterJpaConfig {
 	}
 
 	@Bean
-	public RestfulServer restfulServer(IFhirSystemDao<?, ?> fhirSystemDao, AppProperties appProperties, DaoRegistry daoRegistry, Optional<MdmProviderLoader> mdmProviderProvider, IJpaSystemProvider jpaSystemProvider, ResourceProviderFactory resourceProviderFactory, JpaStorageSettings jpaStorageSettings, ISearchParamRegistry searchParamRegistry, IValidationSupport theValidationSupport, DatabaseBackedPagingProvider databaseBackedPagingProvider, CustomLoggingInterceptor loggingInterceptor, Optional<TerminologyUploaderProvider> terminologyUploaderProvider, Optional<SubscriptionTriggeringProvider> subscriptionTriggeringProvider, Optional<CorsInterceptor> corsInterceptor, IInterceptorBroadcaster interceptorBroadcaster, Optional<BinaryAccessProvider> binaryAccessProvider, BinaryStorageInterceptor binaryStorageInterceptor, IValidatorModule validatorModule, Optional<GraphQLProvider> graphQLProvider, BulkDataExportProvider bulkDataExportProvider, BulkDataImportProvider bulkDataImportProvider, ValueSetOperationProvider theValueSetOperationProvider, ReindexProvider reindexProvider, PartitionManagementProvider partitionManagementProvider, Optional<RepositoryValidatingInterceptor> repositoryValidatingInterceptor, IPackageInstallerSvc packageInstallerSvc, ThreadSafeResourceDeleterSvc theThreadSafeResourceDeleterSvc, ApplicationContext appContext, Optional<IpsOperationProvider> theIpsOperationProvider) {
+	public RestfulServer restfulServer(IFhirSystemDao<?, ?> fhirSystemDao, AppProperties appProperties, DaoRegistry daoRegistry, Optional<MdmProviderLoader> mdmProviderProvider, IJpaSystemProvider jpaSystemProvider, ResourceProviderFactory resourceProviderFactory, JpaStorageSettings jpaStorageSettings, ISearchParamRegistry searchParamRegistry, IValidationSupport theValidationSupport, DatabaseBackedPagingProvider databaseBackedPagingProvider, LoggingInterceptor loggingInterceptor, Optional<TerminologyUploaderProvider> terminologyUploaderProvider, Optional<SubscriptionTriggeringProvider> subscriptionTriggeringProvider, Optional<CorsInterceptor> corsInterceptor, IInterceptorBroadcaster interceptorBroadcaster, Optional<BinaryAccessProvider> binaryAccessProvider, BinaryStorageInterceptor binaryStorageInterceptor, IValidatorModule validatorModule, Optional<GraphQLProvider> graphQLProvider, BulkDataExportProvider bulkDataExportProvider, BulkDataImportProvider bulkDataImportProvider, ValueSetOperationProvider theValueSetOperationProvider, ReindexProvider reindexProvider, PartitionManagementProvider partitionManagementProvider, Optional<RepositoryValidatingInterceptor> repositoryValidatingInterceptor, IPackageInstallerSvc packageInstallerSvc, ThreadSafeResourceDeleterSvc theThreadSafeResourceDeleterSvc, ApplicationContext appContext, Optional<IpsOperationProvider> theIpsOperationProvider) {
 		RestfulServer fhirServer = new RestfulServer(fhirSystemDao.getContext());
 
 		List<String> supportedResourceTypes = appProperties.getSupported_resource_types();
@@ -308,6 +310,7 @@ public class StarterJpaConfig {
 		}
 
 		fhirServer.registerInterceptor(loggingInterceptor);
+		fhirServer.registerInterceptor(new CustomLoggingInterceptor());
 
 		/*
 		 * If you are hosting this server at a specific DNS name, the server will try to

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptor/CustomLoggingInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptor/CustomLoggingInterceptor.java
@@ -1,0 +1,51 @@
+package ca.uhn.fhir.jpa.starter.interceptor;
+
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.ObjectUtils;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.slf4j.MDC;
+
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.api.server.ResponseDetails;
+import ca.uhn.fhir.rest.server.interceptor.LoggingInterceptor;
+import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
+
+@Interceptor
+public class CustomLoggingInterceptor extends LoggingInterceptor {
+	private static final String X_CORRELATION_ID = "X-Correlation-ID";
+
+	public CustomLoggingInterceptor() {
+		super();
+	}
+
+	@Hook(Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED)
+	public boolean incomingRequestPreProcessed(HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse) {
+		String corelationId = ObjectUtils.isNotEmpty(httpServletRequest.getHeader(X_CORRELATION_ID))
+				? httpServletRequest.getHeader(X_CORRELATION_ID)
+				: UUID.randomUUID().toString();
+		MDC.put(X_CORRELATION_ID, corelationId);
+		return true;
+	}
+
+	@Hook(Pointcut.SERVER_OUTGOING_RESPONSE)
+	public boolean incomingRequestPostProcessed1(RequestDetails requestDetails,
+			ServletRequestDetails servletRequestDetails, IBaseResource iBaseResource, ResponseDetails responseDetails,
+			HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+		httpServletResponse.addHeader(X_CORRELATION_ID, MDC.get(X_CORRELATION_ID));
+		return true;
+	}
+
+	@Hook(Pointcut.SERVER_PROCESSING_COMPLETED)
+	public void incomingRequestPostProcessed(RequestDetails requestDetails,
+			ServletRequestDetails servletRequestDetails) {
+		MDC.clear();
+	}
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptor/CustomLoggingInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptor/CustomLoggingInterceptor.java
@@ -14,16 +14,12 @@ import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.ResponseDetails;
-import ca.uhn.fhir.rest.server.interceptor.LoggingInterceptor;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 
 @Interceptor
-public class CustomLoggingInterceptor extends LoggingInterceptor {
-	private static final String X_CORRELATION_ID = "X-Correlation-ID";
+public class CustomLoggingInterceptor {
+	private static final String X_CORRELATION_ID = "X-Correlation-Id";
 
-	public CustomLoggingInterceptor() {
-		super();
-	}
 
 	@Hook(Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED)
 	public boolean incomingRequestPreProcessed(HttpServletRequest httpServletRequest,

--- a/src/main/resources/application-custom.yaml
+++ b/src/main/resources/application-custom.yaml
@@ -51,6 +51,7 @@ spring:
 
 hapi:
   fhir:
+    custom-interceptor-classes: ca.uhn.fhir.jpa.starter.interceptor.CustomLoggingInterceptor
     ### This enables the swagger-ui at /fhir/swagger-ui/index.html as well as the /fhir/api-docs (see https://hapifhir.io/hapi-fhir/docs/server_plain/openapi.html)
     openapi_enabled: true
     ### This is the FHIR version. Choose between, DSTU2, DSTU3, R4 or R5

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -2,6 +2,7 @@
 
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder class="net.logstash.logback.encoder.LogstashEncoder">
+		<includeMdcKeyName>X-Correlation-ID</includeMdcKeyName>
 			<fieldNames>
 				<timestamp>[ignore]</timestamp>
 				<version>[ignore]</version>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder class="net.logstash.logback.encoder.LogstashEncoder">
-		<includeMdcKeyName>X-Correlation-ID</includeMdcKeyName>
+		<includeMdcKeyName>X-Correlation-Id</includeMdcKeyName>
 			<fieldNames>
 				<timestamp>[ignore]</timestamp>
 				<version>[ignore]</version>

--- a/src/test/java/ca/uhn/fhir/jpa/starter/interceptor/CustomLoggingInterceptorTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/interceptor/CustomLoggingInterceptorTest.java
@@ -1,0 +1,159 @@
+package ca.uhn.fhir.jpa.starter.interceptor;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Resource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.annotation.IdParam;
+import ca.uhn.fhir.rest.annotation.Read;
+import ca.uhn.fhir.rest.api.EncodingEnum;
+import ca.uhn.fhir.rest.server.IResourceProvider;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.test.utilities.JettyUtil;
+
+@ExtendWith(OutputCaptureExtension.class)
+class CustomLoggingInterceptorTest {
+
+	private static RestfulServer ourServlet;
+	private static boolean ourHitMethod;
+	private static List<Resource> ourReturn;
+	private static int ourPort;
+	private static CloseableHttpClient ourClient;
+	private static Server ourServer;
+	private static final FhirContext ourCtx = FhirContext.forR4();
+	private static ObjectMapper mapper = new ObjectMapper();
+	
+	private static final String PATIENT_ID = "12345";
+	private static final String X_CORRELATION_ID = "X-Correlation-ID";
+	private static final String X_CORRELATION_ID_VALUE = "123454687544644";
+
+	@BeforeEach
+	public void before() throws IOException {
+		MockitoAnnotations.openMocks(this);
+		ourReturn = null;
+		ourHitMethod = false;
+	}
+
+	@BeforeAll
+	public static void beforeClass() throws Exception {
+		ourServer = new Server(0);
+		MockPatientResourceProvider patProvider = new MockPatientResourceProvider();
+		ServletHandler proxyHandler = new ServletHandler();
+		ourServlet = new RestfulServer(ourCtx);
+		ourServlet.setFhirContext(ourCtx);
+		ourServlet.registerProviders(patProvider);
+		ourServlet.setDefaultResponseEncoding(EncodingEnum.JSON);
+		ServletHolder servletHolder = new ServletHolder(ourServlet);
+		proxyHandler.addServletWithMapping(servletHolder, "/fhir/*");
+		ourServer.setHandler(proxyHandler);
+		JettyUtil.startServer(ourServer);
+		ourPort = JettyUtil.getPortForStartedServer(ourServer);
+		PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager(5000, TimeUnit.MILLISECONDS);
+		HttpClientBuilder builder = HttpClientBuilder.create();
+		builder.setConnectionManager(connectionManager);
+		ourClient = builder.build();
+	}
+
+	@Test
+	void testCorrelationIdPresentInRequestHeader(CapturedOutput output) throws Exception {
+		ourServlet.registerInterceptor(new CustomLoggingInterceptor());
+		
+		HttpGet httpGet;
+		HttpResponse status;
+		
+		ourReturn = Collections.singletonList(createPatient(Integer.valueOf(PATIENT_ID)));
+		httpGet = new HttpGet("http://localhost:" + ourPort + "/fhir/Patient/" + PATIENT_ID);
+		httpGet.setHeader(X_CORRELATION_ID, X_CORRELATION_ID_VALUE);
+		status = ourClient.execute(httpGet);
+		await().atMost(200, TimeUnit.MILLISECONDS).until(() -> status.containsHeader("X-Correlation-ID"));
+		assertEquals(200, status.getStatusLine().getStatusCode());
+		assertTrue(ourHitMethod);
+		assertTrue(status.containsHeader(X_CORRELATION_ID));
+		String ExpectedCorrelationId = getCorrelationIdFromLogs(output);
+		assertNotNull(ExpectedCorrelationId);
+		assertEquals(X_CORRELATION_ID_VALUE, ExpectedCorrelationId);
+	}
+
+	@Test
+	void testCorrelationIdNotPresentInRequestHeader(CapturedOutput output) throws Exception {
+		ourServlet.registerInterceptor(new CustomLoggingInterceptor());
+		
+		HttpGet httpGet;
+		HttpResponse status;
+		
+		ourReturn = Collections.singletonList(createPatient(Integer.valueOf(PATIENT_ID)));
+		httpGet = new HttpGet("http://localhost:" + ourPort + "/fhir/Patient/" + PATIENT_ID);
+		status = ourClient.execute(httpGet);
+		await().atMost(200, TimeUnit.MILLISECONDS).until(() -> status.containsHeader(X_CORRELATION_ID));
+		assertEquals(200, status.getStatusLine().getStatusCode());
+		assertTrue(ourHitMethod);
+		assertTrue(status.containsHeader(X_CORRELATION_ID));
+		String ExpectedCorrelationId = getCorrelationIdFromLogs(output);
+		assertNotNull(ExpectedCorrelationId);
+	}
+
+	private String getCorrelationIdFromLogs(CapturedOutput output) throws JsonMappingException, JsonProcessingException {
+		String[] logLines = output.getAll().split("\\n");
+		JsonNode jsonNode = mapper.readTree(logLines[logLines.length - 1].toString());
+		return jsonNode.get(X_CORRELATION_ID).asText();
+	}
+
+	private Resource createPatient(Integer theId) {
+		Patient retVal = new Patient();
+		if (theId != null) {
+			retVal.setId(new IdType("Patient", (long) theId));
+		}
+		retVal.addName().setFamily("FAM");
+		return retVal;
+	}
+
+	public static class MockPatientResourceProvider implements IResourceProvider {
+
+		@Override
+		public Class<? extends IBaseResource> getResourceType() {
+			return Patient.class;
+		}
+
+		@Read(version = true)
+		public Patient read(@IdParam IdType theId) {
+			ourHitMethod = true;
+			if (ourReturn.isEmpty()) {
+				throw new ResourceNotFoundException(theId);
+			}
+			return (Patient) ourReturn.get(0);
+		}
+	}
+}

--- a/src/test/java/ca/uhn/fhir/jpa/starter/interceptor/CustomLoggingInterceptorTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/interceptor/CustomLoggingInterceptorTest.java
@@ -42,6 +42,7 @@ import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.RestfulServer;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.rest.server.interceptor.LoggingInterceptor;
 import ca.uhn.fhir.test.utilities.JettyUtil;
 
 @ExtendWith(OutputCaptureExtension.class)
@@ -57,7 +58,7 @@ class CustomLoggingInterceptorTest {
 	private static ObjectMapper mapper = new ObjectMapper();
 	
 	private static final String PATIENT_ID = "12345";
-	private static final String X_CORRELATION_ID = "X-Correlation-ID";
+	private static final String X_CORRELATION_ID = "X-Correlation-Id";
 	private static final String X_CORRELATION_ID_VALUE = "123454687544644";
 
 	@BeforeEach
@@ -76,6 +77,8 @@ class CustomLoggingInterceptorTest {
 		ourServlet.setFhirContext(ourCtx);
 		ourServlet.registerProviders(patProvider);
 		ourServlet.setDefaultResponseEncoding(EncodingEnum.JSON);
+		ourServlet.registerInterceptor(new LoggingInterceptor());
+		ourServlet.registerInterceptor(new CustomLoggingInterceptor());
 		ServletHolder servletHolder = new ServletHolder(ourServlet);
 		proxyHandler.addServletWithMapping(servletHolder, "/fhir/*");
 		ourServer.setHandler(proxyHandler);


### PR DESCRIPTION
**Overview**

- Added the CustomLoggingInterceptor to check X-Correlation-Id in the request header and will generate new if not present.
- Added the Junit tests to verify that the correlation Id is logged according to the conditions in the CustomLoggingInterceptor.

**How it was tested**

- Tested by running the tests locally.

**Checklist**

- [x] The title contains a short meaningful summary
- [x]  I have added a link to this PR in the Jira issue
- [x]  I have described how this was tested
- [ ]  I have included screen shots for changes that affect the user interface
- [ ]  I have updated unit tests
- [x]  I have run unit tests locally
- [ ]  I have updated documentation (including README)