### PR TITLE
Adds ability to configure id_strategy

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -2,6 +2,7 @@ package ca.uhn.fhir.jpa.starter;
 
 
 import ca.uhn.fhir.context.FhirVersionEnum;
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings.IdStrategyEnum;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings.ClientIdStrategyEnum;
 import ca.uhn.fhir.jpa.model.entity.NormalizedQuantitySearchLevel;
 import ca.uhn.fhir.jpa.packages.PackageInstallationSpec;
@@ -63,6 +64,7 @@ public class AppProperties {
   private String server_address = null;
   private EncodingEnum default_encoding = EncodingEnum.JSON;
   private FhirVersionEnum fhir_version = FhirVersionEnum.R4;
+  private IdStrategyEnum id_strategy = IdStrategyEnum.SEQUENTIAL_NUMERIC;
   private ClientIdStrategyEnum client_id_strategy = ClientIdStrategyEnum.ALPHANUMERIC;
   private List<String> supported_resource_types = new ArrayList<>();
   private List<Bundle.BundleType> allowed_bundle_types = null;
@@ -280,6 +282,14 @@ public class AppProperties {
 
   public void setLogger(Logger logger) {
     this.logger = logger;
+  }
+
+  public IdStrategyEnum getId_strategy() {
+    return id_strategy;
+  }
+
+  public void setId_strategy(IdStrategyEnum id_strategy) {
+    this.id_strategy = id_strategy;
   }
 
   public ClientIdStrategyEnum getClient_id_strategy() {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -174,10 +174,14 @@ public class FhirServerConfigCommon {
 		jpaStorageSettings.setDeferIndexingForCodesystemsOfSize(
 				appProperties.getDefer_indexing_for_codesystems_of_size());
 
+		jpaStorageSettings.setResourceServerIdStrategy(appProperties.getId_strategy());
 		if (appProperties.getClient_id_strategy() == JpaStorageSettings.ClientIdStrategyEnum.ANY) {
 			jpaStorageSettings.setResourceServerIdStrategy(JpaStorageSettings.IdStrategyEnum.UUID);
 			jpaStorageSettings.setResourceClientIdStrategy(appProperties.getClient_id_strategy());
 		}
+		ourLog.info("Server configured to use server id strategy of {}", jpaStorageSettings.getResourceServerIdStrategy());
+		ourLog.info("Server configured to use client id strategy of {}", jpaStorageSettings.getResourceClientIdStrategy());
+
 		// Parallel Batch GET execution settings
 		jpaStorageSettings.setBundleBatchPoolSize(appProperties.getBundle_batch_pool_size());
 		jpaStorageSettings.setBundleBatchPoolSize(appProperties.getBundle_batch_pool_max_size());

--- a/src/main/resources/application-custom.yaml
+++ b/src/main/resources/application-custom.yaml
@@ -124,6 +124,7 @@ hapi:
     enforce_referential_integrity_on_write: false
     etag_support_enabled: true
     expunge_enabled: true
+    #    id_strategy: SEQUENTIAL_NUMERIC
     #    client_id_strategy: ALPHANUMERIC
     #    fhirpath_interceptor_enabled: false
     filter_search_enabled: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -132,6 +132,7 @@ hapi:
     #    enforce_referential_integrity_on_write: false
     #    etag_support_enabled: true
     #    expunge_enabled: true
+    #    id_strategy: SEQUENTIAL_NUMERIC
     #    client_id_strategy: ALPHANUMERIC
     #    fhirpath_interceptor_enabled: false
     #    filter_search_enabled: true


### PR DESCRIPTION
**Overview**

- Adds the ability to configure the `id_strategy` independently from the `client_id_strategy`.

**How it was tested**

- Built and ran unit tests
- Configured docker-compose to use PostgreSQL, started it, and ran all of our integration tests against it.

**Checklist**

- [x] The title contains a short meaningful summary
- [x]  I have added a link to this PR in the Jira issue
- [x]  I have described how this was tested
- [ ]  I have included screen shots for changes that affect the user interface
- [ ]  I have updated unit tests
- [x]  I have run unit tests locally
- [ ]  I have updated documentation (including README)