### PR TITLE
Enables the well-known smart-configuration even if OAuth is not enabed

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -453,18 +453,20 @@ public class StarterJpaConfig {
 			fhirServer.registerProviders(partitionManagementProvider);
 		}
 
-		// Support for OAuth2 and API_KEY authentication
+		// Support for OAuth 2.0 authentication
 		if (appProperties.getOauth().getEnabled()) {
 			fhirServer.registerInterceptor(new CapabilityStatementCustomizer(appProperties));
 			fhirServer.registerInterceptor(new CustomAuthorizationInterceptor(appProperties));
 			fhirServer.registerInterceptor(new CustomSearchNarrowingInterceptor(appProperties));
-			fhirServer.registerInterceptor(new SmartWellKnownInterceptor(appProperties));
 			FhirVersionEnum fhirVersion = fhirServer.getFhirContext().getVersion().getVersion();
 			if (fhirVersion != FhirVersionEnum.R5) {
 				// Utilize the consent interceptor to simulate a patient compartment for the Task resource
 				fhirServer.registerInterceptor(new ConsentInterceptor(new CustomConsentService(daoRegistry, appProperties)));
 			}
 		}
+
+		// Support for SMART on FHIR launchers
+		fhirServer.registerInterceptor(new SmartWellKnownInterceptor(appProperties));
 
 		repositoryValidatingInterceptor.ifPresent(fhirServer::registerInterceptor);
 


### PR DESCRIPTION
**Overview**

- Enables the `/.well-known/smart-configuration` endpoint even if OAuth is not enabled. This is used by some smart-launchers regardless of OAuth being enabled.

**How it was tested**

- Built and ran unit tests (updated Postman integration tests in our internal git repo)
- Configured docker-compose to disable OAuth, started the server and manually navigated to the smart-configuration endpoint to see that it was returning the expected results.

**Checklist**

- [x] The title contains a short meaningful summary
- [x]  I have added a link to this PR in the Jira issue
- [x]  I have described how this was tested
- [ ]  I have included screen shots for changes that affect the user interface
- [ ]  I have updated unit tests
- [x]  I have run unit tests locally
- [ ]  I have updated documentation (including README)