### PR TITLE
Sync with the upstream v7.0.2

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           images: ${{ env.IMAGES }}
           tags: |
-            type=match,pattern=images/(.*),group=1,enable=${{github.event_name != 'pull_request'}}
+            type=match,pattern=image/(.*),group=1,enable=${{github.event_name != 'pull_request'}}
            
 
       - name: Container meta for tomcat image
@@ -34,7 +34,7 @@ jobs:
         with:
           images: ${{ env.IMAGES }}
           tags: |
-            type=match,pattern=images/(.*),group=1,enable=${{github.event_name != 'pull_request'}}
+            type=match,pattern=image/(.*),group=1,enable=${{github.event_name != 'pull_request'}}
           flavor: |
             suffix=-tomcat,onlatest=true
 

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           images: ${{ env.IMAGES }}
           tags: |
-            type=match,pattern=image-(.*),group=1,enable=${{github.event_name != 'pull_request'}}
+            type=match,pattern=images/(.*),group=1,enable=${{github.event_name != 'pull_request'}}
            
 
       - name: Container meta for tomcat image
@@ -34,7 +34,7 @@ jobs:
         with:
           images: ${{ env.IMAGES }}
           tags: |
-            type=match,pattern=image-(.*),group=1,enable=${{github.event_name != 'pull_request'}}
+            type=match,pattern=images/(.*),group=1,enable=${{github.event_name != 'pull_request'}}
           flavor: |
             suffix=-tomcat,onlatest=true
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,16 @@ or
 
 2) classes will be instantiated via reflection if no matching Bean is found
 
+## Adding custom operations(providers)
+Custom operations(providers) can be registered with the server by including the property `hapi.fhir.custom-provider-classes`. This will take a comma separated list of fully-qualified class names which will be registered with the server.
+Providers will be discovered in one of two ways:
+
+1) discovered from the Spring application context as existing Beans (can be used in conjunction with `hapi.fhir.custom-bean-packages`) or registered with Spring via other methods
+
+or
+
+2) classes will be instantiated via reflection if no matching Bean is found
+
 ## Customizing The Web Testpage UI
 
 The UI that comes with this server is an exact clone of the server available at [http://hapi.fhir.org](http://hapi.fhir.org). You may skin this UI if you'd like. For example, you might change the introductory text or replace the logo with your own.

--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -37,6 +37,7 @@ public class AppProperties {
   private Boolean allow_override_default_search_params = true;
   private Boolean auto_create_placeholder_reference_targets = false;
   private final Set<String> auto_version_reference_at_paths = new HashSet<>();
+  private Boolean language_search_parameter_enabled = false;
   private Boolean dao_scheduling_enabled = true;
   private Boolean delete_expunge_enabled = false;
   private Boolean enable_index_missing_fields = false;
@@ -607,6 +608,14 @@ public Cors getCors() {
 
 	public void setApp_content_path(String app_content_path) {
 		this.app_content_path = app_content_path;
+	}
+
+	public Boolean getLanguage_search_parameter_enabled() {
+		return language_search_parameter_enabled;
+	}
+
+	public void setLanguage_search_parameter_enabled(Boolean language_search_parameter_enabled) {
+		this.language_search_parameter_enabled = language_search_parameter_enabled;
 	}
 
 	public static class Cors {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -97,12 +97,16 @@ public class AppProperties {
 
   private final List<String> custom_interceptor_classes = new ArrayList<>();
 
+	private final List<String> custom_provider_classes = new ArrayList<>();
 
 
 	public List<String> getCustomInterceptorClasses() {
     return custom_interceptor_classes;
   }
 
+	public List<String> getCustomProviderClasses() {
+		return custom_provider_classes;
+	}
 
 
 	public Boolean getOpenapi_enabled() {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -3,6 +3,7 @@ package ca.uhn.fhir.jpa.starter;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings.ClientIdStrategyEnum;
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings.IdStrategyEnum;
 import ca.uhn.fhir.jpa.model.entity.NormalizedQuantitySearchLevel;
 import ca.uhn.fhir.jpa.packages.PackageInstallationSpec;
 import ca.uhn.fhir.rest.api.EncodingEnum;
@@ -65,6 +66,7 @@ public class AppProperties {
   private EncodingEnum default_encoding = EncodingEnum.JSON;
   private FhirVersionEnum fhir_version = FhirVersionEnum.R4;
   private ClientIdStrategyEnum client_id_strategy = ClientIdStrategyEnum.ALPHANUMERIC;
+  private IdStrategyEnum server_id_strategy = null;
   private List<String> supported_resource_types = new ArrayList<>();
   private List<Bundle.BundleType> allowed_bundle_types = null;
   private Boolean narrative_enabled = true;
@@ -263,7 +265,15 @@ public Cors getCors() {
     this.client_id_strategy = client_id_strategy;
   }
 
-	public boolean getAdvanced_lucene_indexing() {
+  public IdStrategyEnum getServer_id_strategy() {
+    return server_id_strategy;
+  }
+
+  public void setServer_id_strategy(IdStrategyEnum server_id_strategy) {
+    this.server_id_strategy = server_id_strategy;
+  }
+
+  public boolean getAdvanced_lucene_indexing() {
 		return this.advanced_lucene_indexing;
 	}
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -111,6 +111,7 @@ public class FhirServerConfigCommon {
 		jpaStorageSettings.setSchedulingDisabled(!appProperties.getDao_scheduling_enabled());
 		jpaStorageSettings.setDeleteExpungeEnabled(appProperties.getDelete_expunge_enabled());
 		jpaStorageSettings.setExpungeEnabled(appProperties.getExpunge_enabled());
+		jpaStorageSettings.setLanguageSearchParameterEnabled(appProperties.getLanguage_search_parameter_enabled());
 		if (appProperties.getSubscription() != null
 				&& appProperties.getSubscription().getEmail() != null)
 			jpaStorageSettings.setEmailFromAddress(

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -174,10 +174,27 @@ public class FhirServerConfigCommon {
 		jpaStorageSettings.setDeferIndexingForCodesystemsOfSize(
 				appProperties.getDefer_indexing_for_codesystems_of_size());
 
+		jpaStorageSettings.setResourceClientIdStrategy(appProperties.getClient_id_strategy());
+		ourLog.info("Server configured to use '" + appProperties.getClient_id_strategy() + "' Client ID Strategy");
+
+		// Set and/or recommend default Server ID Strategy of UUID when using the ANY Client ID Strategy
 		if (appProperties.getClient_id_strategy() == JpaStorageSettings.ClientIdStrategyEnum.ANY) {
-			jpaStorageSettings.setResourceServerIdStrategy(JpaStorageSettings.IdStrategyEnum.UUID);
-			jpaStorageSettings.setResourceClientIdStrategy(appProperties.getClient_id_strategy());
+			if (appProperties.getServer_id_strategy() == null) {
+				ourLog.info("Defaulting server to use '" + JpaStorageSettings.IdStrategyEnum.UUID
+						+ "' Server ID Strategy when using the '" + JpaStorageSettings.ClientIdStrategyEnum.ANY
+						+ "' Client ID Strategy");
+				appProperties.setServer_id_strategy(JpaStorageSettings.IdStrategyEnum.UUID);
+			} else if (appProperties.getServer_id_strategy() != JpaStorageSettings.IdStrategyEnum.UUID) {
+				ourLog.warn("WARNING: '" + JpaStorageSettings.IdStrategyEnum.UUID
+						+ "' Server ID Strategy is highly recommended when using the '"
+						+ JpaStorageSettings.ClientIdStrategyEnum.ANY + "' Client ID Strategy");
+			}
 		}
+		if (appProperties.getServer_id_strategy() != null) {
+			jpaStorageSettings.setResourceServerIdStrategy(appProperties.getServer_id_strategy());
+			ourLog.info("Server configured to use '" + appProperties.getServer_id_strategy() + "' Server ID Strategy");
+		}
+
 		// Parallel Batch GET execution settings
 		jpaStorageSettings.setBundleBatchPoolSize(appProperties.getBundle_batch_pool_size());
 		jpaStorageSettings.setBundleBatchPoolSize(appProperties.getBundle_batch_pool_max_size());

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -178,6 +178,11 @@ hapi:
     # or will be instantiated via reflection using an no-arg contructor; then registered with the server  
     #custom-interceptor-classes:  
 
+    # comma-separated list of fully qualified provider classes. 
+    # classes listed here will be fetched from the Spring context when combined with 'custom-bean-packages', 
+    # or will be instantiated via reflection using an no-arg contructor; then registered with the server  
+    #custom-provider-classes:  
+    
     # Threadpool size for BATCH'ed GETs in a bundle.
     #    bundle_batch_pool_size: 10
     #    bundle_batch_pool_max_size: 50

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -139,6 +139,7 @@ hapi:
     #    etag_support_enabled: true
     #    expunge_enabled: true
     #    client_id_strategy: ALPHANUMERIC
+    #    server_id_strategy: SEQUENTIAL_NUMERIC
     #    fhirpath_interceptor_enabled: false
     #    filter_search_enabled: true
     #    graphql_enabled: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,7 @@
+#Uncomment the following lines to enable the fhir endpoint to be available at /example/path/fhir instead of /fhir
+#server:
+#  servlet:
+#    context-path: /example/path
 #Adds the option to go to eg. http://localhost:8080/actuator/health for seeing the running configuration
 #see https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints
 management:
@@ -11,8 +15,8 @@ spring:
     #allow-bean-definition-overriding: true
   flyway:
     enabled: false
-    check-location: false
     baselineOnMigrate: true
+    fail-on-missing-locations: false
   datasource:
     #url: 'jdbc:h2:file:./target/database/h2'
     url: jdbc:h2:mem:test_mem
@@ -127,6 +131,7 @@ hapi:
     advanced_lucene_indexing: false
     bulk_export_enabled: false
     bulk_import_enabled: false
+    #    language_search_parameter_enabled: true
     #    enforce_referential_integrity_on_delete: false
     # This is an experimental feature, and does not fully support _total and other FHIR features.
     #    enforce_referential_integrity_on_delete: false

--- a/src/test/java/ca/uhn/fhir/jpa/starter/CustomOperationTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/CustomOperationTest.java
@@ -1,0 +1,71 @@
+package ca.uhn.fhir.jpa.starter;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
+import org.hl7.fhir.r4.model.Binary;
+import org.hl7.fhir.r4.model.Parameters;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {Application.class}, properties = {
+		"hapi.fhir.custom-bean-packages=some.custom.pkg1",
+		"hapi.fhir.custom-provider-classes=some.custom.pkg1.CustomOperationBean,some.custom.pkg1.CustomOperationPojo",
+		"spring.datasource.url=jdbc:h2:mem:dbr4",
+		"hapi.fhir.cr_enabled=false",
+		// "hapi.fhir.enable_repository_validating_interceptor=true",
+		"hapi.fhir.fhir_version=r4"
+})
+
+class CustomOperationTest {
+
+	@LocalServerPort
+	private int port;
+
+	private IGenericClient client;
+	private FhirContext ctx;
+
+	@BeforeEach
+	void setUp() {
+		ctx = FhirContext.forR4();
+		ctx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
+		ctx.getRestfulClientFactory().setSocketTimeout(1200 * 1000);
+		String ourServerBase = "http://localhost:" + port + "/fhir/";
+		client = ctx.newRestfulGenericClient(ourServerBase);
+
+		// Properties props = new Properties();
+		// props.put("spring.autoconfigure.exclude", "org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration");
+	}
+
+	@Test
+	void testCustomOperations() {
+
+		// we registered two custom operations via the property 'hapi.fhir.custom-provider-classes'
+		// one is discovered as a Spring Bean ($springBeanOperation), one instantiated via reflection ($pojoOperation)
+		// both should be registered with the server and will add a custom operation.
+
+		// test Spring bean operation
+		MethodOutcome springBeanOutcome = client.operation().onServer().named("$springBeanOperation")
+			.withNoParameters(Parameters.class).returnMethodOutcome().execute();
+
+		// the hapi client will return our operation result (just a string) as a Binary with the string stored as the
+		// data
+		Assertions.assertEquals(200, springBeanOutcome.getResponseStatusCode());
+		Binary springReturnResource = (Binary) springBeanOutcome.getResource();
+		String springReturn = new String(springReturnResource.getData());
+		Assertions.assertEquals("springBean", springReturn);
+
+		// test Pojo bean
+		MethodOutcome pojoOutcome = client.operation().onServer().named("$pojoOperation")
+			.withNoParameters(Parameters.class).returnMethodOutcome().execute();
+
+		Assertions.assertEquals(200, pojoOutcome.getResponseStatusCode());
+		Binary pojoReturnResource = (Binary) pojoOutcome.getResource();
+		String pojoReturn = new String(pojoReturnResource.getData());
+		Assertions.assertEquals("pojo", pojoReturn);
+	}
+}

--- a/src/test/java/some/custom/pkg1/CustomOperationBean.java
+++ b/src/test/java/some/custom/pkg1/CustomOperationBean.java
@@ -1,0 +1,33 @@
+package some.custom.pkg1;
+
+import ca.uhn.fhir.rest.annotation.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.io.IOUtils;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * Code taken from hapi documentation on how to implement an operation which handles its own request/response
+ * <a href="https://hapifhir.io/hapi-fhir/docs/server_plain/rest_operations_operations.html#manually-handing-requestresponse">...</a>
+ */
+
+@Component
+public class CustomOperationBean {
+
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(CustomOperationBean.class);
+
+	@Operation(name = "$springBeanOperation", manualResponse = true, manualRequest = true)
+	public void springBeanOperation(HttpServletRequest theServletRequest, HttpServletResponse theServletResponse)
+		throws IOException {
+		String contentType = theServletRequest.getContentType();
+		byte[] bytes = IOUtils.toByteArray(theServletRequest.getInputStream());
+
+		ourLog.info("Received call with content type {} and {} bytes", contentType, bytes.length);
+
+		theServletResponse.setContentType("text/plain");
+		theServletResponse.getWriter().write("springBean");
+		theServletResponse.getWriter().close();
+	}
+}

--- a/src/test/java/some/custom/pkg1/CustomOperationPojo.java
+++ b/src/test/java/some/custom/pkg1/CustomOperationPojo.java
@@ -1,0 +1,28 @@
+package some.custom.pkg1;
+
+import ca.uhn.fhir.rest.annotation.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class CustomOperationPojo {
+
+	private final Logger LOGGER = LoggerFactory.getLogger(CustomOperationPojo.class);
+
+	@Operation(name = "$pojoOperation", manualResponse = true, manualRequest = true)
+	public void $pojoOperation(HttpServletRequest theServletRequest, HttpServletResponse theServletResponse)
+		throws IOException {
+		String contentType = theServletRequest.getContentType();
+		byte[] bytes = IOUtils.toByteArray(theServletRequest.getInputStream());
+
+		LOGGER.info("Received call with content type {} and {} bytes", contentType, bytes.length);
+
+		theServletResponse.setContentType("text/plain");
+		theServletResponse.getWriter().write("pojo");
+		theServletResponse.getWriter().close();
+	}
+}


### PR DESCRIPTION
**Overview**

- This updates our fork with v7.0.2 in the upstream repo. 
- After resolving conflicts, I compared all changes with the changes in the upstream from v7.0.0 to v7.0.2. Link is [here](https://github.com/hapifhir/hapi-fhir-jpaserver-starter/compare/image/v7.0.0...image/v7.0.2)
- I removed our implementation of "service id strategy" since the changes here are for the same functionality

**How it was tested**

- Built and ran unit tests
- Configured docker-compose to use PostgreSQL, started it, and ran all of our integration tests against it.

**Checklist**

- [x] The title contains a short meaningful summary
- [x]  I have added a link to this PR in the Jira issue
- [x]  I have described how this was tested
- [ ]  I have included screen shots for changes that affect the user interface
- [ ]  I have updated unit tests
- [x]  I have run unit tests locally
- [ ]  I have updated documentation (including README)