### PR TITLE
Remove mssql-jdbc dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,10 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
-        <dependency>
+        <!-- <dependency>
           <groupId>com.microsoft.sqlserver</groupId>
           <artifactId>mssql-jdbc</artifactId>
-        </dependency>
+        </dependency> -->
 
         <!-- Required for Json Logging -->
         <dependency>


### PR DESCRIPTION
**Overview**

- Comments out the `mssql-jdbc` dependency since it is causing builds to fail. We do not use mssql and may re-add it when the upstream fork resolves this issue.

**How it was tested**

- Built and ran unit tests

**Checklist**

- [x] The title contains a short meaningful summary
- [x]  I have added a link to this PR in the Jira issue
- [x]  I have described how this was tested
- [ ]  I have included screen shots for changes that affect the user interface
- [ ]  I have updated unit tests
- [x]  I have run unit tests locally
- [ ]  I have updated documentation (including README)