### PR TITLE
Refactor and add tests for OAuth implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir /app && cp /tmp/hapi-fhir-jpaserver-starter/target/ROOT.war /app/main.
 
 ########### bitnami tomcat version is suitable for debugging and comes with a shell
 ########### it can be built using eg. `docker build --target tomcat .`
-FROM bitnami/tomcat:10.1 AS tomcat
+FROM docker.io/bitnamilegacy/tomcat:10.1.43-debian-12-r0 AS tomcat
 
 USER root
 RUN rm -rf /opt/bitnami/tomcat/webapps/ROOT && \

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -45,10 +45,10 @@ import ca.uhn.fhir.jpa.starter.AppProperties;
 import ca.uhn.fhir.jpa.starter.annotations.OnCorsPresent;
 import ca.uhn.fhir.jpa.starter.annotations.OnImplementationGuidesPresent;
 import ca.uhn.fhir.jpa.starter.common.validation.IRepositoryValidationInterceptorFactory;
-import ca.uhn.fhir.jpa.starter.interceptor.CapabilityStatementCustomizer;
-import ca.uhn.fhir.jpa.starter.interceptor.CustomAuthorizationInterceptor;
-import ca.uhn.fhir.jpa.starter.interceptor.CustomConsentService;
-import ca.uhn.fhir.jpa.starter.interceptor.CustomSearchNarrowingInterceptor;
+import ca.uhn.fhir.jpa.starter.interceptor.OAuthCapabilityStatementCustomizer;
+import ca.uhn.fhir.jpa.starter.interceptor.OAuthAuthorizationInterceptor;
+import ca.uhn.fhir.jpa.starter.interceptor.OAuthConsentService;
+import ca.uhn.fhir.jpa.starter.interceptor.OAuthSearchNarrowingInterceptor;
 import ca.uhn.fhir.jpa.starter.interceptor.SmartWellKnownInterceptor;
 import ca.uhn.fhir.jpa.starter.ig.IImplementationGuideOperationProvider;
 import ca.uhn.fhir.jpa.starter.util.EnvironmentHelper;
@@ -461,13 +461,13 @@ public class StarterJpaConfig {
 
 		// Support for OAuth 2.0 authentication
 		if (appProperties.getOauth().getEnabled()) {
-			fhirServer.registerInterceptor(new CapabilityStatementCustomizer(appProperties));
-			fhirServer.registerInterceptor(new CustomAuthorizationInterceptor(appProperties));
-			fhirServer.registerInterceptor(new CustomSearchNarrowingInterceptor(appProperties));
+			fhirServer.registerInterceptor(new OAuthCapabilityStatementCustomizer(appProperties));
+			fhirServer.registerInterceptor(new OAuthAuthorizationInterceptor(appProperties));
+			fhirServer.registerInterceptor(new OAuthSearchNarrowingInterceptor(appProperties));
 			FhirVersionEnum fhirVersion = fhirServer.getFhirContext().getVersion().getVersion();
 			if (fhirVersion != FhirVersionEnum.R5) {
 				// Utilize the consent interceptor to simulate a patient compartment for the Task resource
-				fhirServer.registerInterceptor(new ConsentInterceptor(new CustomConsentService(daoRegistry, appProperties)));
+				fhirServer.registerInterceptor(new ConsentInterceptor(new OAuthConsentService(daoRegistry, appProperties)));
 			}
 		}
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthAuthorizationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthAuthorizationInterceptor.java
@@ -23,12 +23,13 @@ import ca.uhn.fhir.rest.server.interceptor.auth.IAuthRule;
 import ca.uhn.fhir.rest.server.interceptor.auth.RuleBuilder;
 
 @Interceptor
-public class CustomAuthorizationInterceptor extends AuthorizationInterceptor {
-	private static final Logger logger = LoggerFactory.getLogger(CustomAuthorizationInterceptor.class);
+public class OAuthAuthorizationInterceptor extends AuthorizationInterceptor {
+	private static final Logger logger = LoggerFactory.getLogger(OAuthAuthorizationInterceptor.class);
+	private static final String PATIENT_RESOURCE = "Patient";
 
 	private final AppProperties config;
 
-	public CustomAuthorizationInterceptor(AppProperties config) {
+	public OAuthAuthorizationInterceptor(AppProperties config) {
 		super();
 		this.config = config;
 	}
@@ -51,7 +52,7 @@ public class CustomAuthorizationInterceptor extends AuthorizationInterceptor {
 		} catch (AuthenticationException e) {
 			throw e;
 		} catch (RuntimeException e) {
-			logger.error("Unexpected exception during authorization: {}", e.getMessage());
+			logger.error("Unexpected exception during authorization", e);
 		}
 
 		throw new AuthenticationException("Missing or invalid authorization");
@@ -110,20 +111,23 @@ public class CustomAuthorizationInterceptor extends AuthorizationInterceptor {
 
 			logger.warn("Authorization failure - token doesn't have the required client roles");
 			return unauthorizedRule();
-		} catch (RuntimeException|GeneralSecurityException e) {
-			logger.warn("Authentication failure - unable to decode or verify token: {}", e.getMessage());
-			throw new AuthenticationException("Invalid authorization header", e);
+		} catch (GeneralSecurityException e) {
+			logger.warn("Authentication failure - unable to verify token signature", e);
+			throw new AuthenticationException("Invalid authorization header: token verification failed - " + e.getMessage(), e);
+		} catch (RuntimeException e) {
+			logger.warn("Authentication failure - unable to decode token", e);
+			throw new AuthenticationException("Invalid authorization header: token parsing failed - " + e.getMessage(), e);
 		}
 	}
 
 	private List<IAuthRule> authorizedInPatientCompartmentRule(RequestDetails theRequestDetails, String patientId) {
 		if (OAuth2Helper.canBeInPatientCompartment(theRequestDetails.getResourceName())) {
-			IdType patientIdType = new IdType("Patient", patientId);
+			IdType patientIdType = new IdType(PATIENT_RESOURCE, patientId);
 			return new RuleBuilder()
-				.allow().read().allResources().inCompartment("Patient", patientIdType).andThen()
+				.allow().read().allResources().inCompartment(PATIENT_RESOURCE, patientIdType).andThen()
 				.allow().patch().allRequests().andThen()
-				.allow().write().allResources().inCompartment("Patient", patientIdType).andThen()
-				.allow().delete().allResources().inCompartment("Patient", patientIdType).andThen()
+				.allow().write().allResources().inCompartment(PATIENT_RESOURCE, patientIdType).andThen()
+				.allow().delete().allResources().inCompartment(PATIENT_RESOURCE, patientIdType).andThen()
 				.allow().transaction().withAnyOperation().andApplyNormalRules().andThen()
 				.denyAll()
 				.build();

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthCapabilityStatementCustomizer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthCapabilityStatementCustomizer.java
@@ -1,5 +1,8 @@
 package ca.uhn.fhir.jpa.starter.interceptor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.hl7.fhir.instance.model.api.IBaseConformance;
 import org.hl7.fhir.r4.model.CapabilityStatement;
 import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementRestSecurityComponent;
@@ -11,24 +14,21 @@ import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.jpa.starter.AppProperties;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Interceptor
-public class CapabilityStatementCustomizer {
+public class OAuthCapabilityStatementCustomizer {
 
     private AppProperties config;
 
-    public CapabilityStatementCustomizer(AppProperties config) {
+    public OAuthCapabilityStatementCustomizer(AppProperties config) {
         this.config = config;
     }
 
     @Hook(Pointcut.SERVER_CAPABILITY_STATEMENT_GENERATED)
     public void customize(IBaseConformance theCapabilityStatement) {
- 
+
         // Cast to the appropriate version
         CapabilityStatement cs = (CapabilityStatement) theCapabilityStatement;
- 
+
         if (config.getOauth().getEnabled()) {
 
             // Customize the CapabilityStatement to add a security extension
@@ -40,7 +40,7 @@ public class CapabilityStatementCustomizer {
 
 	private CapabilityStatementRestSecurityComponent getSecurityComponent() {
 		CapabilityStatementRestSecurityComponent security = new CapabilityStatementRestSecurityComponent();
-		
+
         List<Extension> extensions = new ArrayList<>();
 		extensions.add(new Extension(
             "authorize", new UriType(config.getOauth().getAuthorize_url())));
@@ -48,7 +48,7 @@ public class CapabilityStatementCustomizer {
             "token", new UriType(config.getOauth().getToken_url())));
 		extensions.add(new Extension(
             "manage", new UriType(config.getOauth().getManage_url())));
-		
+
         List<Extension> extensionsList = new ArrayList<>();
 		extensionsList.add((Extension) new Extension(
 				new UriType("http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris"))

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthConsentService.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthConsentService.java
@@ -206,7 +206,7 @@ public class OAuthConsentService implements IConsentService {
 
   private boolean isPatchRequestBodyValid(RequestDetails theRequestDetails, String patientId) {
     String contentType = theRequestDetails.getHeader("content-type");
-    if (contentType.equalsIgnoreCase("application/json-patch+json")) {
+    if ("application/json-patch+json".equalsIgnoreCase(contentType)) {
       return isJsonPatchRequestBodyValid(theRequestDetails, patientId);
     }
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthConsentService.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthConsentService.java
@@ -6,7 +6,6 @@ import static com.jayway.jsonpath.Filter.filter;
 import java.util.List;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Property;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
@@ -34,12 +33,12 @@ import ca.uhn.fhir.rest.server.interceptor.consent.IConsentService;
  * For resources in the patient compartment, the authorization interceptor handles it.
  */
 @Service
-public class CustomConsentService implements IConsentService {
-  private static final Logger logger = LoggerFactory.getLogger(CustomConsentService.class);
+public class OAuthConsentService implements IConsentService {
+  private static final Logger logger = LoggerFactory.getLogger(OAuthConsentService.class);
   private final DaoRegistry daoRegistry;
   private final AppProperties config;
 
-  public CustomConsentService(DaoRegistry daoRegistry, AppProperties config) {
+  public OAuthConsentService(DaoRegistry daoRegistry, AppProperties config) {
     this.daoRegistry = daoRegistry;
     this.config = config;
   }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthSearchNarrowingInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthSearchNarrowingInterceptor.java
@@ -13,11 +13,11 @@ import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizedList;
 import ca.uhn.fhir.rest.server.interceptor.auth.SearchNarrowingInterceptor;
 
 @Interceptor
-public class CustomSearchNarrowingInterceptor extends SearchNarrowingInterceptor {
-  private static final Logger logger = LoggerFactory.getLogger(CustomSearchNarrowingInterceptor.class);
+public class OAuthSearchNarrowingInterceptor extends SearchNarrowingInterceptor {
+  private static final Logger logger = LoggerFactory.getLogger(OAuthSearchNarrowingInterceptor.class);
   private final AppProperties config;
 
-	public CustomSearchNarrowingInterceptor(AppProperties config) {
+	public OAuthSearchNarrowingInterceptor(AppProperties config) {
 		super();
 		this.config = config;
 	}

--- a/src/test/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthAuthorizationInterceptorTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthAuthorizationInterceptorTest.java
@@ -1,0 +1,279 @@
+package ca.uhn.fhir.jpa.starter.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+
+import org.hl7.fhir.r4.model.IdType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.http.HttpHeaders;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+import ca.uhn.fhir.jpa.starter.AppProperties;
+import ca.uhn.fhir.jpa.starter.util.OAuth2Helper;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.api.RequestTypeEnum;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
+import ca.uhn.fhir.rest.server.interceptor.auth.IAuthRule;
+import ca.uhn.fhir.rest.server.interceptor.auth.RuleBuilder;
+
+class OAuthAuthorizationInterceptorTest {
+
+	private static final String TEST_TOKEN = "test-token";
+
+	private OAuthAuthorizationInterceptor myInterceptor;
+	private RequestDetails myRequestDetails;
+	private AppProperties myAppProperties;
+	private DecodedJWT myDecodedJwt;
+
+	@BeforeEach
+	void setUp() {
+		myAppProperties = new AppProperties();
+		myAppProperties.getOauth().setEnabled(true);
+		myAppProperties.getOauth().setClient_id("client-a");
+		myAppProperties.getOauth().setUser_role("user-role");
+		myAppProperties.getOauth().setAdmin_role("admin-role");
+		myAppProperties.getOauth().setJwks_url("http://example.org/jwks");
+
+		myInterceptor = new OAuthAuthorizationInterceptor(myAppProperties);
+		myRequestDetails = mock(RequestDetails.class);
+		myDecodedJwt = mock(DecodedJWT.class);
+
+		when(myRequestDetails.getRequestPath()).thenReturn("Patient/123");
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.GET);
+		when(myRequestDetails.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer " + TEST_TOKEN);
+	}
+
+	@Test
+	void buildRuleList_oauthDisabled_allowsAll() {
+		myAppProperties.getOauth().setEnabled(false);
+
+		List<IAuthRule> rules = myInterceptor.buildRuleList(myRequestDetails);
+
+		assertRuleListMatches(rules, allowAllRules());
+	}
+
+	@Test
+	void buildRuleList_missingAuthorization_throwsAuthenticationException() {
+		when(myRequestDetails.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn(null);
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(false);
+
+			assertThrows(AuthenticationException.class, () -> myInterceptor.buildRuleList(myRequestDetails));
+		}
+	}
+
+	@Test
+	void buildRuleList_tokenMetadataPath_isUnauthorized() {
+		when(myRequestDetails.getRequestPath()).thenReturn("fhir/" + Constants.URL_TOKEN_METADATA);
+
+		List<IAuthRule> rules = myInterceptor.buildRuleList(myRequestDetails);
+
+		assertRuleListMatches(rules, unauthorizedRules());
+	}
+
+	@Test
+	void buildRuleList_unexpectedRuntimeInBuildRuleList_throwsAuthenticationException() {
+		when(myRequestDetails.getRequestPath()).thenReturn(null);
+
+		assertThrows(AuthenticationException.class, () -> myInterceptor.buildRuleList(myRequestDetails));
+	}
+
+	@Test
+	void buildRuleList_noClientRoles_isUnauthorized() {
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class);
+			 MockedStatic<JWT> jwtMock = mockStatic(JWT.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getToken(myRequestDetails)).thenReturn(TEST_TOKEN);
+			helperMock.when(() -> OAuth2Helper.verify(any(DecodedJWT.class), anyString())).thenAnswer(invocation -> null);
+			helperMock.when(() -> OAuth2Helper.getClientRoles(myDecodedJwt, "client-a")).thenReturn(List.of());
+			jwtMock.when(() -> JWT.decode(TEST_TOKEN)).thenReturn(myDecodedJwt);
+
+			List<IAuthRule> rules = myInterceptor.buildRuleList(myRequestDetails);
+			assertRuleListMatches(rules, unauthorizedRules());
+			helperMock.verify(() -> OAuth2Helper.verify(myDecodedJwt, "http://example.org/jwks"), times(1));
+			helperMock.verify(() -> OAuth2Helper.getClientRoles(myDecodedJwt, "client-a"), times(1));
+		}
+	}
+
+	@Test
+	void buildRuleList_deleteWithAdminRole_allowsAll() {
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.DELETE);
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class);
+			 MockedStatic<JWT> jwtMock = mockStatic(JWT.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getToken(myRequestDetails)).thenReturn(TEST_TOKEN);
+			helperMock.when(() -> OAuth2Helper.verify(any(DecodedJWT.class), anyString())).thenAnswer(invocation -> null);
+			helperMock.when(() -> OAuth2Helper.getClientRoles(myDecodedJwt, "client-a")).thenReturn(List.of("admin-role"));
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myDecodedJwt, "patient")).thenReturn(null);
+			jwtMock.when(() -> JWT.decode(TEST_TOKEN)).thenReturn(myDecodedJwt);
+
+			List<IAuthRule> rules = myInterceptor.buildRuleList(myRequestDetails);
+			assertRuleListMatches(rules, allowAllRules());
+			helperMock.verify(() -> OAuth2Helper.getClaimAsString(myDecodedJwt, "patient"), times(1));
+		}
+	}
+
+	@Test
+	void buildRuleList_deleteWithoutAdminRole_isUnauthorized() {
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.DELETE);
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class);
+			 MockedStatic<JWT> jwtMock = mockStatic(JWT.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getToken(myRequestDetails)).thenReturn(TEST_TOKEN);
+			helperMock.when(() -> OAuth2Helper.verify(any(DecodedJWT.class), anyString())).thenAnswer(invocation -> null);
+			helperMock.when(() -> OAuth2Helper.getClientRoles(myDecodedJwt, "client-a")).thenReturn(List.of("user-role"));
+			jwtMock.when(() -> JWT.decode(TEST_TOKEN)).thenReturn(myDecodedJwt);
+
+			List<IAuthRule> rules = myInterceptor.buildRuleList(myRequestDetails);
+			assertRuleListMatches(rules, unauthorizedRules());
+		}
+	}
+
+	@Test
+	void buildRuleList_unrelatedRole_isUnauthorized() {
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class);
+			 MockedStatic<JWT> jwtMock = mockStatic(JWT.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getToken(myRequestDetails)).thenReturn(TEST_TOKEN);
+			helperMock.when(() -> OAuth2Helper.verify(any(DecodedJWT.class), anyString())).thenAnswer(invocation -> null);
+			helperMock.when(() -> OAuth2Helper.getClientRoles(myDecodedJwt, "client-a")).thenReturn(List.of("reporting-role"));
+			jwtMock.when(() -> JWT.decode(TEST_TOKEN)).thenReturn(myDecodedJwt);
+
+			List<IAuthRule> rules = myInterceptor.buildRuleList(myRequestDetails);
+			assertRuleListMatches(rules, unauthorizedRules());
+		}
+	}
+
+	@Test
+	void buildRuleList_adminRoleNoPatientClaim_allowsAll() {
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class);
+			 MockedStatic<JWT> jwtMock = mockStatic(JWT.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getToken(myRequestDetails)).thenReturn(TEST_TOKEN);
+			helperMock.when(() -> OAuth2Helper.verify(any(DecodedJWT.class), anyString())).thenAnswer(invocation -> null);
+			helperMock.when(() -> OAuth2Helper.getClientRoles(myDecodedJwt, "client-a")).thenReturn(List.of("admin-role"));
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myDecodedJwt, "patient")).thenReturn(null);
+			jwtMock.when(() -> JWT.decode(TEST_TOKEN)).thenReturn(myDecodedJwt);
+
+			List<IAuthRule> rules = myInterceptor.buildRuleList(myRequestDetails);
+			assertRuleListMatches(rules, allowAllRules());
+		}
+	}
+
+	@Test
+	void buildRuleList_userRoleWithPatientClaim_buildsCompartmentRules() {
+		when(myRequestDetails.getResourceName()).thenReturn("Observation");
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class);
+			 MockedStatic<JWT> jwtMock = mockStatic(JWT.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getToken(myRequestDetails)).thenReturn(TEST_TOKEN);
+			helperMock.when(() -> OAuth2Helper.verify(any(DecodedJWT.class), anyString())).thenAnswer(invocation -> null);
+			helperMock.when(() -> OAuth2Helper.getClientRoles(myDecodedJwt, "client-a")).thenReturn(List.of("user-role"));
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myDecodedJwt, "patient")).thenReturn("456");
+			helperMock.when(() -> OAuth2Helper.canBeInPatientCompartment("Observation")).thenReturn(true);
+			jwtMock.when(() -> JWT.decode(TEST_TOKEN)).thenReturn(myDecodedJwt);
+
+			List<IAuthRule> rules = myInterceptor.buildRuleList(myRequestDetails);
+			assertRuleListMatches(rules, patientCompartmentRules("456"));
+			helperMock.verify(() -> OAuth2Helper.canBeInPatientCompartment("Observation"), times(1));
+		}
+	}
+
+	@Test
+	void buildRuleList_userRoleWithPatientClaim_nonCompartmentResource_allowsAll() {
+		when(myRequestDetails.getResourceName()).thenReturn("Binary");
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class);
+			 MockedStatic<JWT> jwtMock = mockStatic(JWT.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getToken(myRequestDetails)).thenReturn(TEST_TOKEN);
+			helperMock.when(() -> OAuth2Helper.verify(any(DecodedJWT.class), anyString())).thenAnswer(invocation -> null);
+			helperMock.when(() -> OAuth2Helper.getClientRoles(myDecodedJwt, "client-a")).thenReturn(List.of("user-role"));
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myDecodedJwt, "patient")).thenReturn("456");
+			helperMock.when(() -> OAuth2Helper.canBeInPatientCompartment("Binary")).thenReturn(false);
+			jwtMock.when(() -> JWT.decode(TEST_TOKEN)).thenReturn(myDecodedJwt);
+
+			List<IAuthRule> rules = myInterceptor.buildRuleList(myRequestDetails);
+			assertRuleListMatches(rules, allowAllRules());
+			helperMock.verify(() -> OAuth2Helper.canBeInPatientCompartment("Binary"), times(1));
+		}
+	}
+
+	@Test
+	void buildRuleList_tokenVerificationCheckedFailure_throwsAuthenticationException() {
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class);
+			 MockedStatic<JWT> jwtMock = mockStatic(JWT.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getToken(myRequestDetails)).thenReturn(TEST_TOKEN);
+			helperMock.when(() -> OAuth2Helper.verify(any(DecodedJWT.class), anyString()))
+				.thenThrow(new NoSuchAlgorithmException("unsupported"));
+			jwtMock.when(() -> JWT.decode(TEST_TOKEN)).thenReturn(myDecodedJwt);
+
+			assertThrows(AuthenticationException.class, () -> myInterceptor.buildRuleList(myRequestDetails));
+		}
+	}
+
+	@Test
+	void buildRuleList_tokenVerificationFailure_throwsAuthenticationException() {
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class);
+			 MockedStatic<JWT> jwtMock = mockStatic(JWT.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getToken(myRequestDetails)).thenReturn(TEST_TOKEN);
+			helperMock.when(() -> OAuth2Helper.verify(any(DecodedJWT.class), anyString()))
+				.thenThrow(new RuntimeException("bad signature"));
+			jwtMock.when(() -> JWT.decode(TEST_TOKEN)).thenReturn(myDecodedJwt);
+
+			assertThrows(AuthenticationException.class, () -> myInterceptor.buildRuleList(myRequestDetails));
+		}
+	}
+
+	private void assertRuleListMatches(List<IAuthRule> actual, List<IAuthRule> expected) {
+		assertEquals(expected.size(), actual.size(), "Rule count mismatch");
+		for (int i = 0; i < expected.size(); i++) {
+			assertEquals(expected.get(i).toString(), actual.get(i).toString(), "Rule mismatch at index " + i);
+		}
+	}
+
+	private List<IAuthRule> allowAllRules() {
+		return new RuleBuilder()
+			.allowAll()
+			.build();
+	}
+
+	private List<IAuthRule> unauthorizedRules() {
+		return new RuleBuilder()
+			.allow().metadata().andThen()
+			.denyAll()
+			.build();
+	}
+
+	private List<IAuthRule> patientCompartmentRules(String patientId) {
+		IdType patientIdType = new IdType("Patient", patientId);
+		return new RuleBuilder()
+			.allow().read().allResources().inCompartment("Patient", patientIdType).andThen()
+			.allow().patch().allRequests().andThen()
+			.allow().write().allResources().inCompartment("Patient", patientIdType).andThen()
+			.allow().delete().allResources().inCompartment("Patient", patientIdType).andThen()
+			.allow().transaction().withAnyOperation().andApplyNormalRules().andThen()
+			.denyAll()
+			.build();
+	}
+}

--- a/src/test/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthConsentServiceTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthConsentServiceTest.java
@@ -1,0 +1,414 @@
+package ca.uhn.fhir.jpa.starter.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Task;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.jpa.starter.AppProperties;
+import ca.uhn.fhir.jpa.starter.util.OAuth2Helper;
+import ca.uhn.fhir.rest.api.RequestTypeEnum;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.interceptor.consent.ConsentOutcome;
+import ca.uhn.fhir.rest.server.interceptor.consent.IConsentContextServices;
+
+class OAuthConsentServiceTest {
+
+	private OAuthConsentService myConsentService;
+	private DaoRegistry myDaoRegistry;
+	private IFhirResourceDao<IBaseResource> myResourceDao;
+	private AppProperties myAppProperties;
+	private RequestDetails myRequestDetails;
+	private IConsentContextServices myConsentContextServices;
+
+	@BeforeEach
+	@SuppressWarnings("unchecked")
+	void setUp() {
+		myDaoRegistry = mock(DaoRegistry.class);
+		myResourceDao = mock(IFhirResourceDao.class);
+		myAppProperties = new AppProperties();
+		myAppProperties.getOauth().setEnabled(true);
+		myRequestDetails = mock(RequestDetails.class);
+		myConsentContextServices = mock(IConsentContextServices.class);
+		myConsentService = new OAuthConsentService(myDaoRegistry, myAppProperties);
+
+		when(myRequestDetails.getResourceName()).thenReturn("Task");
+		when(myRequestDetails.getId()).thenReturn(new IdType("Task/1"));
+		when(myDaoRegistry.getResourceDao("Task")).thenReturn(myResourceDao);
+	}
+
+	@Test
+	void canSeeResource_oauthDisabled_proceeds() {
+		myAppProperties.getOauth().setEnabled(false);
+
+		ConsentOutcome outcome = myConsentService.canSeeResource(
+			myRequestDetails,
+			createTaskForPatient("123"),
+			myConsentContextServices
+		);
+
+		assertEquals(ConsentOutcome.PROCEED, outcome);
+	}
+
+	@Test
+	void canSeeResource_matchingPatientClaim_proceeds() {
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			ConsentOutcome outcome = myConsentService.canSeeResource(
+				myRequestDetails,
+				createTaskForPatient("123"),
+				myConsentContextServices
+			);
+			assertEquals(ConsentOutcome.PROCEED, outcome);
+		}
+	}
+
+	@Test
+	void canSeeResource_noToken_proceeds() {
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(false);
+
+			ConsentOutcome outcome = myConsentService.canSeeResource(
+				myRequestDetails,
+				createTaskForPatient("123"),
+				myConsentContextServices
+			);
+			assertEquals(ConsentOutcome.PROCEED, outcome);
+		}
+	}
+
+	@Test
+	void canSeeResource_nonTaskRequest_proceeds() {
+		when(myRequestDetails.getResourceName()).thenReturn("Patient");
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+
+			ConsentOutcome outcome = myConsentService.canSeeResource(
+				myRequestDetails,
+				createTaskForPatient("123"),
+				myConsentContextServices
+			);
+			assertEquals(ConsentOutcome.PROCEED, outcome);
+		}
+	}
+
+	@Test
+	void canSeeResource_noPatientClaim_proceeds() {
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn(null);
+
+			ConsentOutcome outcome = myConsentService.canSeeResource(
+				myRequestDetails,
+				createTaskForPatient("123"),
+				myConsentContextServices
+			);
+			assertEquals(ConsentOutcome.PROCEED, outcome);
+		}
+	}
+
+	@Test
+	void canSeeResource_nullResource_rejects() {
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			ConsentOutcome outcome = myConsentService.canSeeResource(
+				myRequestDetails,
+				null,
+				myConsentContextServices
+			);
+			assertEquals(ConsentOutcome.REJECT, outcome);
+		}
+	}
+
+	@Test
+	void canSeeResource_taskWithoutForReference_rejects() {
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			ConsentOutcome outcome = myConsentService.canSeeResource(
+				myRequestDetails,
+				new Task(),
+				myConsentContextServices
+			);
+			assertEquals(ConsentOutcome.REJECT, outcome);
+		}
+	}
+
+	@Test
+	void canSeeResource_nonMatchingPatientClaim_rejects() {
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			ConsentOutcome outcome = myConsentService.canSeeResource(
+				myRequestDetails,
+				createTaskForPatient("999"),
+				myConsentContextServices
+			);
+			assertEquals(ConsentOutcome.REJECT, outcome);
+		}
+	}
+
+	@Test
+	void startOperation_post_matchingPatient_proceeds() {
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.POST);
+		when(myRequestDetails.getResource()).thenReturn(createTaskForPatient("123"));
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			ConsentOutcome outcome = myConsentService.startOperation(myRequestDetails, myConsentContextServices);
+			assertEquals(ConsentOutcome.PROCEED, outcome);
+		}
+	}
+
+	@Test
+	void startOperation_post_nonMatchingPatient_rejects() {
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.POST);
+		when(myRequestDetails.getResource()).thenReturn(createTaskForPatient("999"));
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			ConsentOutcome outcome = myConsentService.startOperation(myRequestDetails, myConsentContextServices);
+			assertEquals(ConsentOutcome.REJECT, outcome);
+		}
+	}
+
+	@Test
+	void startOperation_put_bothMatchingPatients_proceeds() {
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.PUT);
+		when(myRequestDetails.getResource()).thenReturn(createTaskForPatient("123"));
+		when(myResourceDao.read(any(), any(RequestDetails.class))).thenReturn(createTaskForPatient("123"));
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			ConsentOutcome outcome = myConsentService.startOperation(myRequestDetails, myConsentContextServices);
+			assertEquals(ConsentOutcome.PROCEED, outcome);
+		}
+	}
+
+	@Test
+	void startOperation_put_persistentNonMatchingPatient_rejects() {
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.PUT);
+		when(myRequestDetails.getResource()).thenReturn(createTaskForPatient("123"));
+		when(myResourceDao.read(any(), any(RequestDetails.class))).thenReturn(createTaskForPatient("999"));
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			ConsentOutcome outcome = myConsentService.startOperation(myRequestDetails, myConsentContextServices);
+			assertEquals(ConsentOutcome.REJECT, outcome);
+		}
+	}
+
+	@Test
+	void startOperation_patch_validJsonPatch_proceeds() {
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.PATCH);
+		when(myRequestDetails.getHeader("content-type")).thenReturn("application/json-patch+json");
+		when(myResourceDao.read(any(), any(RequestDetails.class))).thenReturn(createTaskForPatient("123"));
+		when(myRequestDetails.loadRequestContents())
+			.thenReturn("[{\"op\":\"replace\",\"path\":\"/for/reference\",\"value\":\"Patient/123\"}]".getBytes());
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			ConsentOutcome outcome = myConsentService.startOperation(myRequestDetails, myConsentContextServices);
+			assertEquals(ConsentOutcome.PROCEED, outcome);
+		}
+	}
+
+	@Test
+	void startOperation_patch_jsonPatchInvalidReference_rejects() {
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.PATCH);
+		when(myRequestDetails.getHeader("content-type")).thenReturn("application/json-patch+json");
+		when(myResourceDao.read(any(), any(RequestDetails.class))).thenReturn(createTaskForPatient("123"));
+		when(myRequestDetails.loadRequestContents())
+			.thenReturn("[{\"op\":\"replace\",\"path\":\"/for/reference\",\"value\":\"Patient/999\"}]".getBytes());
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			ConsentOutcome outcome = myConsentService.startOperation(myRequestDetails, myConsentContextServices);
+			assertEquals(ConsentOutcome.REJECT, outcome);
+		}
+	}
+
+	@Test
+	void startOperation_patch_malformedJson_rejects() {
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.PATCH);
+		when(myRequestDetails.getHeader("content-type")).thenReturn("application/json-patch+json");
+		when(myResourceDao.read(any(), any(RequestDetails.class))).thenReturn(createTaskForPatient("123"));
+		when(myRequestDetails.loadRequestContents()).thenReturn("not-json".getBytes());
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			ConsentOutcome outcome = myConsentService.startOperation(myRequestDetails, myConsentContextServices);
+			assertEquals(ConsentOutcome.REJECT, outcome);
+		}
+	}
+
+	@Test
+	void startOperation_patch_invalidContentType_rejects() {
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.PATCH);
+		when(myRequestDetails.getHeader("content-type")).thenReturn("application/fhir+json");
+		when(myResourceDao.read(any(), any(RequestDetails.class))).thenReturn(createTaskForPatient("123"));
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			ConsentOutcome outcome = myConsentService.startOperation(myRequestDetails, myConsentContextServices);
+			assertEquals(ConsentOutcome.REJECT, outcome);
+		}
+	}
+
+	@Test
+	void startOperation_delete_matchingPersistentPatient_proceeds() {
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.DELETE);
+		when(myResourceDao.read(any(), any(RequestDetails.class))).thenReturn(createTaskForPatient("123"));
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			ConsentOutcome outcome = myConsentService.startOperation(myRequestDetails, myConsentContextServices);
+			assertEquals(ConsentOutcome.PROCEED, outcome);
+		}
+	}
+
+	@Test
+	void startOperation_delete_nonMatchingPersistentPatient_rejects() {
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.DELETE);
+		when(myResourceDao.read(any(), any(RequestDetails.class))).thenReturn(createTaskForPatient("999"));
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			ConsentOutcome outcome = myConsentService.startOperation(myRequestDetails, myConsentContextServices);
+			assertEquals(ConsentOutcome.REJECT, outcome);
+		}
+	}
+
+	@Test
+	void startOperation_oauthDisabled_proceeds() {
+		myAppProperties.getOauth().setEnabled(false);
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.PUT);
+
+		ConsentOutcome outcome = myConsentService.startOperation(myRequestDetails, myConsentContextServices);
+		assertEquals(ConsentOutcome.PROCEED, outcome);
+	}
+
+	@Test
+	void startOperation_nonTaskRequest_proceeds() {
+		when(myRequestDetails.getResourceName()).thenReturn("Patient");
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.PUT);
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+
+			ConsentOutcome outcome = myConsentService.startOperation(myRequestDetails, myConsentContextServices);
+			assertEquals(ConsentOutcome.PROCEED, outcome);
+		}
+	}
+
+	@Test
+	void startOperation_noPatientClaim_proceeds() {
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.PUT);
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn(null);
+
+			ConsentOutcome outcome = myConsentService.startOperation(myRequestDetails, myConsentContextServices);
+			assertEquals(ConsentOutcome.PROCEED, outcome);
+		}
+	}
+
+	@Test
+	void startOperation_getRequestType_proceeds() {
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.GET);
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			ConsentOutcome outcome = myConsentService.startOperation(myRequestDetails, myConsentContextServices);
+			assertEquals(ConsentOutcome.PROCEED, outcome);
+		}
+	}
+
+	@Test
+	void startOperation_nullResourceName_proceeds() {
+		when(myRequestDetails.getResourceName()).thenReturn(null);
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.DELETE);
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+
+			ConsentOutcome outcome = myConsentService.startOperation(myRequestDetails, myConsentContextServices);
+			assertEquals(ConsentOutcome.PROCEED, outcome);
+		}
+	}
+
+	@Test
+	void startOperation_persistentReadThrows_runtimeExceptionPropagates() {
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.PUT);
+		when(myRequestDetails.getResource()).thenReturn(createTaskForPatient("123"));
+		when(myResourceDao.read(any(), any(RequestDetails.class))).thenThrow(new RuntimeException("db fail"));
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			assertThrows(RuntimeException.class, () -> myConsentService.startOperation(myRequestDetails, myConsentContextServices));
+		}
+	}
+
+	@Test
+	void startOperation_patch_missingContentType_runtimeExceptionPropagates() {
+		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.PATCH);
+		when(myRequestDetails.getHeader("content-type")).thenReturn(null);
+		when(myResourceDao.read(any(), any(RequestDetails.class))).thenReturn(createTaskForPatient("123"));
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			assertThrows(RuntimeException.class, () -> myConsentService.startOperation(myRequestDetails, myConsentContextServices));
+		}
+	}
+
+	private Task createTaskForPatient(String patientId) {
+		Task task = new Task();
+		task.setFor(new Reference("Patient/" + patientId));
+		return task;
+	}
+}

--- a/src/test/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthConsentServiceTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthConsentServiceTest.java
@@ -393,7 +393,7 @@ class OAuthConsentServiceTest {
 	}
 
 	@Test
-	void startOperation_patch_missingContentType_runtimeExceptionPropagates() {
+	void startOperation_patch_missingContentType_rejects() {
 		when(myRequestDetails.getRequestType()).thenReturn(RequestTypeEnum.PATCH);
 		when(myRequestDetails.getHeader("content-type")).thenReturn(null);
 		when(myResourceDao.read(any(), any(RequestDetails.class))).thenReturn(createTaskForPatient("123"));
@@ -402,7 +402,8 @@ class OAuthConsentServiceTest {
 			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
 			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
 
-			assertThrows(RuntimeException.class, () -> myConsentService.startOperation(myRequestDetails, myConsentContextServices));
+			ConsentOutcome outcome = myConsentService.startOperation(myRequestDetails, myConsentContextServices);
+			assertEquals(ConsentOutcome.REJECT, outcome);
 		}
 	}
 

--- a/src/test/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthSearchNarrowingInterceptorTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthSearchNarrowingInterceptorTest.java
@@ -1,0 +1,105 @@
+package ca.uhn.fhir.jpa.starter.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import ca.uhn.fhir.jpa.starter.AppProperties;
+import ca.uhn.fhir.jpa.starter.util.OAuth2Helper;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizedList;
+
+class OAuthSearchNarrowingInterceptorTest {
+
+	private static final String EXPECTED_COMPARTMENT = "Patient/123";
+
+	private TestableOAuthSearchNarrowingInterceptor myInterceptor;
+	private RequestDetails myRequestDetails;
+	private AppProperties myAppProperties;
+
+	@BeforeEach
+	void setUp() {
+		myAppProperties = new AppProperties();
+		myAppProperties.getOauth().setEnabled(true);
+		myInterceptor = new TestableOAuthSearchNarrowingInterceptor(myAppProperties);
+		myRequestDetails = mock(RequestDetails.class);
+	}
+
+	@Test
+	void buildAuthorizedList_oauthDisabled_returnsEmptyList() {
+		myAppProperties.getOauth().setEnabled(false);
+
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			AuthorizedList list = myInterceptor.callBuildAuthorizedList(myRequestDetails);
+			assertFalse(containsCompartment(list, EXPECTED_COMPARTMENT));
+		}
+	}
+
+	@Test
+	void buildAuthorizedList_noBearerToken_returnsEmptyList() {
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(false);
+
+			AuthorizedList list = myInterceptor.callBuildAuthorizedList(myRequestDetails);
+			assertFalse(containsCompartment(list, EXPECTED_COMPARTMENT));
+		}
+	}
+
+	@Test
+	void buildAuthorizedList_noPatientClaim_returnsEmptyList() {
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn(null);
+
+			AuthorizedList list = myInterceptor.callBuildAuthorizedList(myRequestDetails);
+			assertFalse(containsCompartment(list, EXPECTED_COMPARTMENT));
+		}
+	}
+
+	@Test
+	void buildAuthorizedList_withPatientClaim_addsPatientCompartment() {
+		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
+			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
+			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
+
+			AuthorizedList list = myInterceptor.callBuildAuthorizedList(myRequestDetails);
+			assertTrue(containsCompartment(list, EXPECTED_COMPARTMENT));
+		}
+	}
+
+	private boolean containsCompartment(AuthorizedList theList, String theExpectedCompartment) {
+		try {
+			for (Field nextField : AuthorizedList.class.getDeclaredFields()) {
+				nextField.setAccessible(true);
+				Object fieldValue = nextField.get(theList);
+				if (fieldValue instanceof Collection<?> collection && collection.contains(theExpectedCompartment)) {
+					return true;
+				}
+			}
+		} catch (IllegalAccessException e) {
+			throw new RuntimeException("Unable to inspect AuthorizedList internals", e);
+		}
+		return false;
+	}
+
+	private static class TestableOAuthSearchNarrowingInterceptor extends OAuthSearchNarrowingInterceptor {
+		TestableOAuthSearchNarrowingInterceptor(AppProperties config) {
+			super(config);
+		}
+
+		AuthorizedList callBuildAuthorizedList(RequestDetails theRequestDetails) {
+			return super.buildAuthorizedList(theRequestDetails);
+		}
+	}
+}

--- a/src/test/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthSearchNarrowingInterceptorTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/interceptor/OAuthSearchNarrowingInterceptorTest.java
@@ -1,105 +1,96 @@
 package ca.uhn.fhir.jpa.starter.interceptor;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.lang.reflect.Field;
-import java.util.Collection;
+import java.util.HashMap;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jpa.starter.AppProperties;
 import ca.uhn.fhir.jpa.starter.util.OAuth2Helper;
+import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
-import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizedList;
+import ca.uhn.fhir.rest.server.IRestfulServerDefaults;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 class OAuthSearchNarrowingInterceptorTest {
 
-	private static final String EXPECTED_COMPARTMENT = "Patient/123";
-
-	private TestableOAuthSearchNarrowingInterceptor myInterceptor;
+	private OAuthSearchNarrowingInterceptor myInterceptor;
 	private RequestDetails myRequestDetails;
+	private HttpServletRequest myHttpServletRequest;
+	private HttpServletResponse myHttpServletResponse;
 	private AppProperties myAppProperties;
 
 	@BeforeEach
 	void setUp() {
 		myAppProperties = new AppProperties();
 		myAppProperties.getOauth().setEnabled(true);
-		myInterceptor = new TestableOAuthSearchNarrowingInterceptor(myAppProperties);
+		myInterceptor = new OAuthSearchNarrowingInterceptor(myAppProperties);
+
 		myRequestDetails = mock(RequestDetails.class);
+		myHttpServletRequest = mock(HttpServletRequest.class);
+		myHttpServletResponse = mock(HttpServletResponse.class);
+
+		IRestfulServerDefaults serverDefaults = mock(IRestfulServerDefaults.class);
+		when(serverDefaults.getFhirContext()).thenReturn(FhirContext.forR4Cached());
+
+		when(myRequestDetails.getServer()).thenReturn(serverDefaults);
+		when(myRequestDetails.getRestOperationType()).thenReturn(RestOperationTypeEnum.SEARCH_TYPE);
+		when(myRequestDetails.getResourceName()).thenReturn("Observation");
+		when(myRequestDetails.getParameters()).thenReturn(new HashMap<>());
 	}
 
 	@Test
-	void buildAuthorizedList_oauthDisabled_returnsEmptyList() {
+	void hookIncomingRequestPostProcessed_oauthDisabled_doesNotNarrow() {
 		myAppProperties.getOauth().setEnabled(false);
 
 		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
 			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
 			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
 
-			AuthorizedList list = myInterceptor.callBuildAuthorizedList(myRequestDetails);
-			assertFalse(containsCompartment(list, EXPECTED_COMPARTMENT));
+			myInterceptor.hookIncomingRequestPostProcessed(myRequestDetails, myHttpServletRequest, myHttpServletResponse);
+			verify(myRequestDetails, never()).setParameters(any());
 		}
 	}
 
 	@Test
-	void buildAuthorizedList_noBearerToken_returnsEmptyList() {
+	void hookIncomingRequestPostProcessed_noBearerToken_doesNotNarrow() {
 		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
 			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(false);
 
-			AuthorizedList list = myInterceptor.callBuildAuthorizedList(myRequestDetails);
-			assertFalse(containsCompartment(list, EXPECTED_COMPARTMENT));
+			myInterceptor.hookIncomingRequestPostProcessed(myRequestDetails, myHttpServletRequest, myHttpServletResponse);
+			verify(myRequestDetails, never()).setParameters(any());
 		}
 	}
 
 	@Test
-	void buildAuthorizedList_noPatientClaim_returnsEmptyList() {
+	void hookIncomingRequestPostProcessed_noPatientClaim_doesNotNarrow() {
 		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
 			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
 			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn(null);
 
-			AuthorizedList list = myInterceptor.callBuildAuthorizedList(myRequestDetails);
-			assertFalse(containsCompartment(list, EXPECTED_COMPARTMENT));
+			myInterceptor.hookIncomingRequestPostProcessed(myRequestDetails, myHttpServletRequest, myHttpServletResponse);
+			verify(myRequestDetails, never()).setParameters(any());
 		}
 	}
 
 	@Test
-	void buildAuthorizedList_withPatientClaim_addsPatientCompartment() {
+	void hookIncomingRequestPostProcessed_withPatientClaim_narrowsSearch() {
 		try (MockedStatic<OAuth2Helper> helperMock = mockStatic(OAuth2Helper.class)) {
 			helperMock.when(() -> OAuth2Helper.hasToken(myRequestDetails)).thenReturn(true);
 			helperMock.when(() -> OAuth2Helper.getClaimAsString(myRequestDetails, "patient")).thenReturn("123");
 
-			AuthorizedList list = myInterceptor.callBuildAuthorizedList(myRequestDetails);
-			assertTrue(containsCompartment(list, EXPECTED_COMPARTMENT));
-		}
-	}
-
-	private boolean containsCompartment(AuthorizedList theList, String theExpectedCompartment) {
-		try {
-			for (Field nextField : AuthorizedList.class.getDeclaredFields()) {
-				nextField.setAccessible(true);
-				Object fieldValue = nextField.get(theList);
-				if (fieldValue instanceof Collection<?> collection && collection.contains(theExpectedCompartment)) {
-					return true;
-				}
-			}
-		} catch (IllegalAccessException e) {
-			throw new RuntimeException("Unable to inspect AuthorizedList internals", e);
-		}
-		return false;
-	}
-
-	private static class TestableOAuthSearchNarrowingInterceptor extends OAuthSearchNarrowingInterceptor {
-		TestableOAuthSearchNarrowingInterceptor(AppProperties config) {
-			super(config);
-		}
-
-		AuthorizedList callBuildAuthorizedList(RequestDetails theRequestDetails) {
-			return super.buildAuthorizedList(theRequestDetails);
+			myInterceptor.hookIncomingRequestPostProcessed(myRequestDetails, myHttpServletRequest, myHttpServletResponse);
+			verify(myRequestDetails).setParameters(any());
 		}
 	}
 }


### PR DESCRIPTION
First phase for adding `AuditEvent` support, which will require changes the OAuth interceptor. To ensure there are no regressions, I asked Copilot to help me refactor some of our enhancements for OAuth and to add tests. There are no functional changes to the OAuth support.

The update to the `Dockerfile` is necessary because it was using a deprecated image. The next release of hapi-fhir-jpaserver-starter (upstream) has this update. The plan is to upgrade our fork from the upstream repo to a later release after the `AuditEvent` changes are completed.